### PR TITLE
Add Hunter module and SuperWoW spell-id debuff detection

### DIFF
--- a/AutoRota.lua
+++ b/AutoRota.lua
@@ -15,7 +15,7 @@
 -- ============================================================
 
 AutoRota = {
-    ver = "0.6.2b",
+    ver = "0.7.0b",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,
@@ -220,6 +220,81 @@ function AutoRota:BuffTime(name)
     return tl or 0, st or 0
 end
 
+-- ============================================================
+-- Target debuff detection. One pass per press over the target's debuffs,
+-- resolving each to its spell NAME through SuperWoW's spell id (the id is
+-- returned by UnitDebuff and mapped with SpellInfo, the same id path the
+-- player buff snapshot uses). Name matching is exact and rank/locale proof,
+-- so it replaces the old icon-fragment guessing. The icon texture is kept in
+-- the snapshot as a fallback for clients without SuperWoW (or ids we cannot
+-- map), so detection degrades to the previous behaviour rather than breaking.
+-- ============================================================
+function AutoRota:SnapshotTargetDebuffs()
+    local byName, list = {}, {}
+    if UnitExists("target") then
+        for i = 1, 40 do
+            -- vanilla returns (texture, applications, dispelType); SuperWoW
+            -- appends the spell id. applications is always the 2nd return, so
+            -- the id is the first NUMERIC value among the trailing returns
+            -- (dispelType is a string or nil and is skipped naturally).
+            local tex, stacks, d3, d4, d5 = UnitDebuff("target", i)
+            if not tex then break end
+            stacks = stacks or 0
+            local id
+            if type(d3) == "number" then id = d3
+            elseif type(d4) == "number" then id = d4
+            elseif type(d5) == "number" then id = d5 end
+            if id and SpellInfo then
+                if id < -1 then id = id + 65536 end
+                local nm = SpellInfo(id)
+                if nm and nm ~= "" and byName[nm] == nil then byName[nm] = stacks end
+            end
+            table.insert(list, { tex = tex, stacks = stacks })
+        end
+    end
+    self.tdebuffSnap = { byName = byName, list = list }
+    self.tdebuffSnapT = GetTime()
+end
+
+-- Returns up (bool), stacks. Tries the exact spell name first (SuperWoW id
+-- path), then the optional icon-fragment fallback. Builds the snapshot on
+-- demand when it is stale, so slash commands and the UI work outside a press.
+function AutoRota:ScanTargetDebuff(name, texFrag)
+    if not (self.tdebuffSnap and self.tdebuffSnapT == GetTime()) then
+        self:SnapshotTargetDebuffs()
+    end
+    local snap = self.tdebuffSnap
+    if name and name ~= "" then
+        local s = snap.byName[name]
+        if s ~= nil then return true, s end
+    end
+    if texFrag and texFrag ~= "" then
+        for i = 1, table.getn(snap.list) do
+            local e = snap.list[i]
+            if e.tex and string.find(e.tex, texFrag) then return true, e.stacks end
+        end
+    end
+    return false, 0
+end
+
+function AutoRota:TargetDebuffUp(name, texFrag)
+    local up = self:ScanTargetDebuff(name, texFrag)
+    return up
+end
+
+function AutoRota:TargetDebuffStacks(name, texFrag)
+    local up, st = self:ScanTargetDebuff(name, texFrag)
+    if up then return st or 0 end
+    return 0
+end
+
+-- True when SuperWoW's id->name path is available, so a debuff without a
+-- known icon fragment can still be tracked exactly (used by modules to decide
+-- between exact upkeep and a blind reapply timer).
+function AutoRota:CanResolveDebuffNames()
+    return SpellInfo ~= nil
+end
+
 function AutoRota:ManaPct()
     local mx = UnitManaMax("player")
     if mx and mx > 0 then return UnitMana("player") / mx * 100 end
@@ -283,11 +358,22 @@ end
 function AutoRota:Debug()
     DEFAULT_CHAT_FRAME:AddMessage("--- AutoRota debug ---", 1, 0.8, 0.0)
     if UnitExists("target") then
-        DEFAULT_CHAT_FRAME:AddMessage("Target debuff textures:", 1, 0.8, 0.0)
+        DEFAULT_CHAT_FRAME:AddMessage("Target debuffs (name / stacks / texture):", 1, 0.8, 0.0)
         local any = false
         for i = 1, 40 do
-            local t = UnitDebuff("target", i)
-            if t then any = true; DEFAULT_CHAT_FRAME:AddMessage("  [" .. i .. "] " .. t) end
+            local t, stacks, d3, d4, d5 = UnitDebuff("target", i)
+            if not t then break end
+            any = true
+            local id
+            if type(d3) == "number" then id = d3
+            elseif type(d4) == "number" then id = d4
+            elseif type(d5) == "number" then id = d5 end
+            local nm = "?"
+            if id and SpellInfo then
+                if id < -1 then id = id + 65536 end
+                nm = SpellInfo(id) or "?"
+            end
+            DEFAULT_CHAT_FRAME:AddMessage("  [" .. i .. "] " .. nm .. " / " .. (stacks or 0) .. " / " .. t)
         end
         if not any then DEFAULT_CHAT_FRAME:AddMessage("  (none)") end
     else
@@ -455,6 +541,7 @@ function AutoRota:RunRotation()
     if self.active.meleeAutoAttack ~= false and not IsAddOnLoaded("SuperCleveRoidMacros") then self:EnsureAutoAttack() end
 
     self:SnapshotBuffs()
+    self:SnapshotTargetDebuffs()
     self.active:Rotate(cfg)
     UIErrorsFrame:Clear()
 end

--- a/AutoRota.toc
+++ b/AutoRota.toc
@@ -2,7 +2,7 @@
 ## Title: AutoRota
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW)
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 0.6.2b
+## Version: 0.7.0b
 ## SavedVariablesPerCharacter: AutoRotaDB
 
 AutoRota.lua
@@ -10,6 +10,8 @@ AutoRota_UI.lua
 AutoRota_Minimap.lua
 classes\Class_Druid.lua
 classes\Class_Druid_UI.lua
+classes\Class_Hunter.lua
+classes\Class_Hunter_UI.lua
 classes\Class_Paladin.lua
 classes\Class_Paladin_UI.lua
 classes\Class_Rogue.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to **AutoRota** are documented here. Versions are listed new
 
 ---
 
+## v0.7.0b — Hunter Module & Spell-ID Debuff Detection
+
+Adds the sixth class module, **Hunter**, and replaces the addon's icon-fragment
+debuff detection with exact **SuperWoW spell-id** matching across every class.
+
+### 🏹 Added: Hunter (Beta)
+- A ranged-priority engine built around **Auto Shot**. Auto Shot is a toggle, so it is kept running rather than recast every press — a press that fires an instant never stops the shot. When Auto Shot is on an action bar it is detected via `IsAutoRepeatAction`; when it is not, an assumed-on flag per target prevents accidentally toggling it off, and leaving combat resets it.
+- **Priority:** Mend Pet when the pet drops below your slider → *Aspect of the Hawk* upkeep → *Hunter's Mark* → the chosen *Sting* → AoE (*Volley* then *Multi-Shot* when `/ar aoe` is on) → melee weave → *Multi-Shot* → *Arcane Shot* → *Aimed Shot* (queued so it never clips). One GCD ability per press, off-GCD layers (pet attack, *Rapid Fire* / *Bestial Wrath*) fire and continue.
+- **One sting slot** (Serpent / Scorpid / Viper / none), switchable from the panel or `/ar sting serpent|scorpid|viper|none`. Stings and *Hunter's Mark* are applied once per target and refreshed only when they fall off.
+- **Melee weave (opt-in):** when the target is in melee range, melee auto-attack is started and *Raptor Strike* is used, so a mob in your face still takes hits instead of standing in the ranged dead zone.
+- **Cooldown automation** (always / elite only / off) for *Rapid Fire* and *Bestial Wrath*, the same three-state model as the other classes, plus four templates: `starter`, `marksmanship`, `beastmastery`, `survival`.
+
+### 🎯 Changed: Exact Debuff Detection (all classes)
+- Target debuffs are now resolved to their exact **spell name** through SuperWoW's spell id (the same id path the player-buff snapshot already used), built once per press into a shared snapshot in the core. The previous **icon-texture fragment** match is kept as an automatic fallback for clients without SuperWoW, so detection degrades to the old behaviour rather than breaking.
+- This makes upkeep exact and rank/locale-proof everywhere: the **Warlock** now tracks *every* curse precisely instead of blind-timer reapplying any curse without a hand-verified texture (the old "Add more textures once confirmed" limitation is gone when SuperWoW is present); the **Paladin** judgement debuffs, **Druid** bleeds/DoTs, and **Warrior** *Sunder Armor* stacks all read from the same exact source.
+- `/ar debug` now prints each target debuff as **name / stacks / texture**, so any remaining unmapped effect is easy to identify.
+
+### 📝 Notes
+- The spell-id path requires SuperWoW (already a hard requirement). Without it, every class falls back to the prior texture-fragment behaviour automatically.
+- Hunter sting/Hunter's Mark icon textures are intentionally not hard-coded: with SuperWoW the exact name is used, and without it a short reapply timer keeps them up.
+
+---
+
 ## v0.6.2b — Druid Defensive Bear
 
 Adds an adaptive **HP-managed defensive form switch** to the Druid, built on

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutoRota (v0.6.2b)
+# AutoRota (v0.7.0b)
 
 AutoRota is a lightweight, robust, Configurable one-button rotation, multi class (Turtle WoW 1.12 / SuperWoW). Unlike standard "monolithic" 1.12 macros or basic script loops, AutoRota uses a modern modular architecture, automated frame-by-frame management, and smart situational logic to execute combat rotations.
 
@@ -11,6 +11,7 @@ Version 0.4 introduces a complete graphical configuration panel and database sys
 - **Multi-Class Architecture:** A unified, lightweight UI shell dynamically swaps control panels and rotation rules based on the class you are currently playing.
 - **Smart Profile Management:** Create, save, rename, and activate multiple custom setup profiles (e.g., *Starter*, *Leveling*, *PvP*, *Raid-DPS*) seamlessly in-game.
 - **Turtle WoW & SuperWoW Optimized:** Fully compatible with custom SuperWoW features such as spell queueing (`QueueSpellByName`), weapon swing timing, and custom custom class expansions (e.g., Rogue's *Noxious Assault*, Paladin's *Holy Strike*).
+- **Exact Debuff Detection:** Target debuffs are resolved to their precise spell name via SuperWoW spell ids (built once per press in the core), so upkeep is rank- and locale-proof for every class. Clients without SuperWoW fall back automatically to icon-texture matching.
 - **Zero-Clipping Logic:** Rotations run on strict single-cast priorities with early returns. The addon ensures exactly one primary action executes per frame to prevent spell clipping or overlapping global cooldowns (GCD).
 - **Lightweight Per-Press Cost:** Spellbook lookups, profile validity, the auto-attack button, and player buffs are all cached or snapshotted (and refreshed automatically when you learn spells or edit profiles), so spamming the macro costs a handful of table reads instead of repeated full spellbook, action-bar, and buff scans.
 - **Minimap Button:** A draggable minimap button opens the configuration panel with a click (right-click runs the rotation once). Hide or show it with `/armap`.
@@ -21,7 +22,7 @@ Version 0.4 introduces a complete graphical configuration panel and database sys
 
 ### 🛡️ Paladin `(Beta)`
 Engineered around an intelligent "Roleless Seal Model" optimized for low-level leveling up to high-tier raiding:
-- **Debuff Upkeep:** Automatically tracks target debuffs via texture fragments. Applies your chosen *Debuff Seal* (e.g., *Seal of the Crusader* or *Seal of Wisdom*) exactly once per mob, then switches immediately to your *Damage Seal*.
+- **Debuff Upkeep:** Automatically tracks target judgement debuffs by exact spell name (SuperWoW spell ids, with texture fallback). Applies your chosen *Debuff Seal* (e.g., *Seal of the Crusader* or *Seal of Wisdom*) exactly once per mob, then switches immediately to your *Damage Seal*.
 - **Low-Level Safety Guard:** Built-in safeguards automatically bypass the Judgement/Debuff loop if your Paladin is under level 10 and hasn't learned `Judgement` yet, keeping your damage seal active as a permanent auto-attack buff.
 - **Hysteresis Resource Management:** Fully configurable independent health and mana safety floors. When triggered, the engine swaps to *Seal of Light* or *Seal of Wisdom* until your resource stabilizes back to your high threshold.
 - **Seal Twisting Support:** If enabled, delays damage judgements until precisely `< 0.4s` before your next white swing to combine weapon procs and judgements simultaneously.
@@ -51,7 +52,7 @@ A roleless, toggle-driven engine covering Arms, Fury, and Protection from early 
 
 Optimized for efficient DoT upkeep and resource management:
 
-* **DoT Priority Engine:** Keeps your enabled damage-over-time effects up in strict priority — *Immolate*, then your chosen Curse, then *Corruption*, then *Siphon Life* — detected by target debuff texture, with a per-target landing memory so cast-time DoTs are never double-queued while still in the air.
+* **DoT Priority Engine:** Keeps your enabled damage-over-time effects up in strict priority — *Immolate*, then your chosen Curse, then *Corruption*, then *Siphon Life* — detected by exact spell name (SuperWoW spell ids, with texture fallback), with a per-target landing memory so cast-time DoTs are never double-queued while still in the air. Every curse is now tracked precisely, not just the ones with a hand-verified icon.
 * **Curse Selection:** One curse per target, switchable from the panel or mid-fight with `/ar curse <alias>` (`coa`, `coe`, `cos`, `cow`, `cor`, `cot`, `cod`, `none`).
 * **Life Tap Integration:** Hysteresis-style management that triggers *Life Tap* only when mana dips below your threshold **and** health is safely above your floor.
 * **Configurable Filler:** When every enabled DoT is up — wand (mana-free), *Shadow Bolt*, or *Drain Life*. A *Nightfall* option fires the free instant *Shadow Bolt* the moment *Shadow Trance* procs.
@@ -70,6 +71,17 @@ Cat (DPS), Bear (Tank), and Balance (Caster/Moonkin) in one form-adaptive engine
 * **Powershifting (opt-in):** In the Shred style, when energy bottoms out below your slider the rotation shifts to caster and straight back into Cat for a fresh energy bar — and **never while Tiger's Fury is active**, so the buff is not thrown away.
 * **Stealth Opener & Upkeep:** Opens from *Prowl* with *Ravage* (auto, if known) or *Pounce*, and keeps *Faerie Fire (Feral)* and *Tiger's Fury* running.
 * **Bear Tanking:** *Faerie Fire* and *Demoralizing Roar* upkeep, *Maul* as the single-target rage dump, *Swipe* leading the priority when AoE mode is toggled (`/ar aoe`), and optional *Enrage* when rage-starved (in combat only — it lowers armor, so it is off by default).
+
+### 🏹 Hunter `(Beta)`
+
+A ranged-priority engine built around **Auto Shot**, with optional melee weave and pet support:
+
+* **Auto Shot Upkeep:** Auto Shot is a toggle, so the rotation keeps it *running* rather than recasting it each press — an instant fired between shots never stops it. Detected via `IsAutoRepeatAction` when it is on a bar, with an assumed-on safeguard per target when it is not, so it is never accidentally toggled off.
+* **Shot Priority:** Mend Pet (below your slider) → *Aspect of the Hawk* upkeep → *Hunter's Mark* → your chosen *Sting* → AoE → *Multi-Shot* → *Arcane Shot* → *Aimed Shot*. Exactly one GCD ability per press; off-GCD cooldowns and pet attack fire and continue. *Aimed Shot* is queued through SuperWoW so it never clips the current shot.
+* **One Sting Slot:** *Serpent*, *Scorpid*, or *Viper* (or none), from the panel or `/ar sting serpent|scorpid|viper|none`. Stings and *Hunter's Mark* are applied once per target and refreshed only when they fall off.
+* **Melee Weave (opt-in):** When the target is in melee range, melee auto-attack starts and *Raptor Strike* is used, so a mob in your face still takes hits instead of standing in the ranged dead zone.
+* **AoE & Cooldowns:** *Volley* leads then *Multi-Shot* fills when AoE mode is on (`/ar aoe`). *Rapid Fire* and *Bestial Wrath* automate on the usual three-state model — always, elite/boss only, or off.
+* **Pet Support:** Sends the pet to attack each press and heals it with *Mend Pet* when it drops below your configured health percent.
 
 ---
 

--- a/classes/Class_Druid.lua
+++ b/classes/Class_Druid.lua
@@ -173,15 +173,13 @@ end
 
 function M:TargetHasTexture(frag)
     if not frag or frag == "" then return false end
-    for i = 1, 40 do
-        local t = UnitDebuff("target", i)
-        if t and string.find(t, frag) then return true end
-    end
-    return false
+    return self:TargetDebuffUp(nil, frag)
 end
 
+-- The debuffTex keys are the spell names, so they also serve as the exact
+-- name match (SuperWoW id path); the texture stays as the fallback.
 function M:DebuffUp(spellName)
-    return self:TargetHasTexture(self.debuffTex[spellName])
+    return self:TargetDebuffUp(spellName, self.debuffTex[spellName])
 end
 
 -- Affordable and learned. UnitMana("player") reads the active power, so

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -1,0 +1,361 @@
+-- ============================================================
+-- Class_Hunter  -  hunter module for AutoRota
+-- Turtle WoW 1.12 (SuperWoW). Ranged priority, configurable, all specs.
+-- ============================================================
+-- Model:
+--  * Hunters fight at range around Auto Shot, weaving instants between
+--    shots. Auto Shot is a toggle (like the warlock wand), so it is kept
+--    running rather than recast every press: a press that fires an instant
+--    never stops the shot.
+--  * One GCD ability is chosen per press by strict priority with early
+--    returns, the same single-cast discipline the other modules use. Off-GCD
+--    layers (pet attack, burst cooldowns) fire and continue.
+--  * Debuff upkeep (Hunter's Mark, the chosen Sting) uses the core's
+--    SuperWoW name detection with a per-target throttle, so it is applied
+--    exactly once and refreshed only when it falls off.
+--  * AoE has no reliable enemy counter on 1.12, so it is a manual toggle
+--    (/ar aoe) that leads with Volley / Multi-Shot.
+--  * Cooldowns follow the rogue/warrior pattern: pop always, only on
+--    elite/boss, or never. Rapid Fire plus Bestial Wrath / Intimidation
+--    when those are known.
+--  * Optional melee weave: when the target is in melee range, Raptor Strike
+--    is used and melee auto-attack is started, so a mob in your face still
+--    takes damage instead of standing in a dead zone.
+-- ============================================================
+
+local M = AutoRota:NewClassModule("HUNTER")
+M.uiTitle = "Hunter"
+M.uiHeight = 644
+M.meleeAutoAttack = false   -- ranged class: Auto Shot is managed here instead
+
+-- Chat output is shared in the core; this shim keeps call sites unchanged.
+local function msgOut(text, r, g, b) AutoRota:Msg(text, r, g, b) end
+
+-- Light throttle so a rapid press burst does not re-toggle Auto Shot or
+-- re-apply an instant debuff several times before it registers.
+local MEND_PET_CD = 12   -- Mend Pet HoT lasts ~15s, refresh a little early
+
+-- The three stings are mutually exclusive (one debuff slot). Durations are
+-- only used as the reapply interval on clients without SuperWoW name
+-- resolution; with SuperWoW the real debuff is seen and the timer is moot.
+M.STINGS = { "Serpent Sting", "Scorpid Sting", "Viper Sting" }
+local STING_DUR = {
+    ["Serpent Sting"] = 15,
+    ["Scorpid Sting"] = 20,
+    ["Viper Sting"]   = 8,
+}
+
+M.stingAlias = {
+    serpent = "Serpent Sting", ss = "Serpent Sting",
+    scorpid = "Scorpid Sting", sco = "Scorpid Sting",
+    viper = "Viper Sting", vs = "Viper Sting",
+    none = "",
+}
+
+M.spellAlias = {
+    mark = "useHuntersMark", hm = "useHuntersMark",
+    arcane = "useArcaneShot", as = "useArcaneShot",
+    multi = "useMultiShot", ms = "useMultiShot",
+    aimed = "useAimedShot", aim = "useAimedShot",
+    volley = "useVolley",
+    aspect = "useAspectHawk", hawk = "useAspectHawk",
+    raptor = "useRaptorStrike", rs = "useRaptorStrike",
+    mend = "useMendPet",
+}
+
+-- Templates: starting presets, copied into the char's saved profiles once.
+M.templates = {
+    starter = {  -- valid from level 1: Mark, Serpent Sting, Arcane, Auto Shot
+        useHuntersMark = true, sting = "Serpent Sting",
+        useArcaneShot = true, useMultiShot = false, useAimedShot = false,
+        aoeMode = false, useVolley = false,
+        useAspectHawk = true,
+        petAttack = true, useMendPet = true, mendPetHp = 50,
+        popCDs = false, autoCDElite = false,
+        useRaptorStrike = true,
+    },
+    marksmanship = {
+        useHuntersMark = true, sting = "Serpent Sting",
+        useArcaneShot = true, useMultiShot = true, useAimedShot = true,
+        aoeMode = false, useVolley = false,
+        useAspectHawk = true,
+        petAttack = true, useMendPet = true, mendPetHp = 40,
+        popCDs = false, autoCDElite = true,
+        useRaptorStrike = false,
+    },
+    beastmastery = {
+        useHuntersMark = true, sting = "Serpent Sting",
+        useArcaneShot = true, useMultiShot = true, useAimedShot = false,
+        aoeMode = false, useVolley = false,
+        useAspectHawk = true,
+        petAttack = true, useMendPet = true, mendPetHp = 60,
+        popCDs = false, autoCDElite = true,
+        useRaptorStrike = false,
+    },
+    survival = {
+        useHuntersMark = true, sting = "Serpent Sting",
+        useArcaneShot = true, useMultiShot = true, useAimedShot = false,
+        aoeMode = false, useVolley = false,
+        useAspectHawk = true,
+        petAttack = true, useMendPet = true, mendPetHp = 50,
+        popCDs = false, autoCDElite = true,
+        useRaptorStrike = true,
+    },
+}
+
+function M:NormalizeProfile(c)
+    local b = {
+        useHuntersMark = true, sting = "Serpent Sting",
+        useArcaneShot = true, useMultiShot = false, useAimedShot = false,
+        aoeMode = false, useVolley = false,
+        useAspectHawk = true,
+        petAttack = true, useMendPet = true, mendPetHp = 50,
+        popCDs = false, autoCDElite = false,
+        useRaptorStrike = true,
+    }
+    for k, v in pairs(b) do
+        if c[k] == nil then c[k] = v end
+    end
+    -- a stored sting the player never had should still normalize cleanly
+    if type(c.sting) ~= "string" then c.sting = "Serpent Sting" end
+    return c
+end
+
+-- Only an explicitly chosen sting the character cannot cast is flagged; every
+-- other ability degrades gracefully through KnowsSpell while leveling.
+function M:ProfileValidity(cfg)
+    local missing = {}
+    if cfg.sting ~= "" and not self:KnowsSpell(cfg.sting) then table.insert(missing, cfg.sting) end
+    return (table.getn(missing) == 0), missing
+end
+
+function M:AvailableStingsOf()
+    local out = {}
+    for i = 1, table.getn(self.STINGS) do
+        if self:KnowsSpell(self.STINGS[i]) then table.insert(out, self.STINGS[i]) end
+    end
+    return out
+end
+
+-- ============================================================
+-- Auto Shot upkeep. Auto Shot is an auto-repeat toggle: casting it while it
+-- is already running turns it OFF. So it is only (re)started when it is not
+-- repeating. IsAutoRepeatAction sees it when it is on an action bar; when it
+-- is not, we fall back to an assumed-on flag per target so we never toggle it
+-- off by accident.
+-- ============================================================
+function M:AutoShotting()
+    local slot = self.autoShotSlot
+    if slot and IsAutoRepeatAction(slot) then return true end
+    for s = 1, 120 do
+        if IsAutoRepeatAction(s) then self.autoShotSlot = s; return true end
+    end
+    return false
+end
+
+function M:EnsureAutoShot()
+    if self:AutoShotting() then self.autoShotOn = true; return end
+    local id = self:TargetId()
+    -- already started on this target and not visibly repeating (Auto Shot not
+    -- on a bar): leave it, recasting would only toggle it off.
+    if self.autoShotOn and self.autoShotTarget == id then return end
+    CastSpellByName("Auto Shot")
+    self.autoShotOn = true
+    self.autoShotTarget = id
+end
+
+-- ============================================================
+-- Debuff upkeep helper. Returns true if a cast was issued this press.
+-- Detection prefers the exact spell name (SuperWoW), with a per-target
+-- throttle so the instant is applied once and not re-queued before it
+-- registers. Without name resolution, `interval` is the blind reapply timer.
+-- ============================================================
+M.debuffThrottle = {}
+function M:MaintainDebuff(name, interval)
+    if not self:KnowsSpell(name) then return false end
+    if self:TargetDebuffUp(name, nil) then return false end
+    local detectable = AutoRota:CanResolveDebuffNames()
+    local id = self:TargetId()
+    local rec = self.debuffThrottle[name]
+    local now = GetTime()
+    if rec and rec.id == id and rec.t and (now - rec.t) <= (interval or 3) then
+        return false   -- detectable: still landing; otherwise assumed up on the timer
+    end
+    self.debuffThrottle[name] = { id = id, t = now }
+    return self:Cast(name)
+end
+
+function M:PetHPPct()
+    if not UnitExists("pet") then return 100 end
+    local mx = UnitHealthMax("pet")
+    if mx and mx > 0 then return UnitHealth("pet") / mx * 100 end
+    return 100
+end
+
+-- ============================================================
+-- Rotation
+-- ============================================================
+function M:Rotate(cfg)
+    local now      = GetTime()
+    local cls      = UnitClassification("target")
+    local isElite  = (cls == "worldboss" or cls == "elite" or cls == "rareelite")
+    local aoe      = cfg.aoeMode and true or false
+    local inCombat = UnitAffectingCombat("player")
+    local inMelee  = self:InMeleeRange()
+    local meleeWeave = cfg.useRaptorStrike and inMelee and self:KnowsSpell("Raptor Strike")
+
+    if self.trace then
+        self:Trace("sting=" .. (cfg.sting ~= "" and cfg.sting or "-")
+            .. " mark=" .. (cfg.useHuntersMark and (self:TargetDebuffUp("Hunter's Mark", nil) and "Y" or "n") or "-")
+            .. " auto=" .. (self:AutoShotting() and "Y" or (self.autoShotOn and "assumed" or "N"))
+            .. " melee=" .. (inMelee and "Y" or "N")
+            .. " aoe=" .. (aoe and "Y" or "N")
+            .. " elite=" .. (isElite and "Y" or "N")
+            .. " pet=" .. (UnitExists("pet") and string.format("%.0f%%", self:PetHPPct()) or "-"))
+    end
+
+    -- ----------------------------------------------------------------
+    -- 0. Off-GCD / fire-and-continue layer
+    -- ----------------------------------------------------------------
+    -- 0a. Pet attack.
+    if cfg.petAttack and UnitExists("pet") then PetAttack() end
+
+    -- 0b. Burst cooldowns (off the GCD), gated by the pop mode and combat.
+    local popBurst = cfg.popCDs or (cfg.autoCDElite and isElite)
+    if popBurst and inCombat then
+        if self:KnowsSpell("Rapid Fire") and self:IsReady("Rapid Fire") then self:Cast("Rapid Fire") end
+        if self:KnowsSpell("Bestial Wrath") and self:IsReady("Bestial Wrath") then self:Cast("Bestial Wrath") end
+    end
+
+    -- 0c. Ranged auto-attack upkeep, unless we are meleeing something on top
+    --     of us (then start melee swings instead so Raptor Strike can land).
+    if meleeWeave then
+        AutoRota:EnsureAutoAttack()
+    else
+        self:EnsureAutoShot()
+    end
+
+    -- ----------------------------------------------------------------
+    -- 1. GCD priority (strict, one cast per press via early return)
+    -- ----------------------------------------------------------------
+
+    -- 1a. Mend Pet when the pet is hurting (throttled, the HoT lasts ~15s).
+    if cfg.useMendPet and UnitExists("pet") and self:KnowsSpell("Mend Pet") then
+        if self:PetHPPct() < (cfg.mendPetHp or 50) and (now - (self.mendPetT or 0)) > MEND_PET_CD then
+            if self:Cast("Mend Pet") then self.mendPetT = now; return end
+        end
+    end
+
+    -- 1b. Keep Aspect of the Hawk up (ranged attack speed/power).
+    if cfg.useAspectHawk and self:KnowsSpell("Aspect of the Hawk")
+        and not self:HasBuff("Aspect of the Hawk") then
+        if self:Cast("Aspect of the Hawk") then return end
+    end
+
+    -- 1c. Hunter's Mark upkeep.
+    if cfg.useHuntersMark then
+        if self:MaintainDebuff("Hunter's Mark", 110) then return end
+    end
+
+    -- 1d. Sting upkeep (the one configured slot).
+    if cfg.sting ~= "" then
+        if self:MaintainDebuff(cfg.sting, STING_DUR[cfg.sting] or 12) then return end
+    end
+
+    -- 1e. AoE leads with Volley (channel) then Multi-Shot when toggled on.
+    if aoe then
+        if cfg.useVolley and self:KnowsSpell("Volley") and self:IsReady("Volley") then
+            if self:Cast("Volley") then return end
+        end
+        if cfg.useMultiShot and self:KnowsSpell("Multi-Shot") and self:IsReady("Multi-Shot") then
+            if self:Cast("Multi-Shot") then return end
+        end
+    end
+
+    -- 1f. Melee weave: Raptor Strike queues on the next melee swing.
+    if meleeWeave and self:IsReady("Raptor Strike") then
+        if self:Cast("Raptor Strike") then return end
+    end
+
+    -- 1g. Multi-Shot on cooldown (single target too, when enabled).
+    if cfg.useMultiShot and self:KnowsSpell("Multi-Shot") and self:IsReady("Multi-Shot") then
+        if self:Cast("Multi-Shot") then return end
+    end
+
+    -- 1h. Arcane Shot on cooldown, the staple instant nuke.
+    if cfg.useArcaneShot and self:KnowsSpell("Arcane Shot") and self:IsReady("Arcane Shot") then
+        if self:Cast("Arcane Shot") then return end
+    end
+
+    -- 1i. Aimed Shot (Marksmanship). It has a cast time, so it is queued to
+    --     avoid clipping the current shot when SuperWoW is present.
+    if cfg.useAimedShot and self:KnowsSpell("Aimed Shot") and self:IsReady("Aimed Shot") then
+        if QueueSpellByName then QueueSpellByName("Aimed Shot") else CastSpellByName("Aimed Shot") end
+        return
+    end
+end
+
+-- ============================================================
+-- Class specific slash subcommands, dispatched from the core
+-- ============================================================
+function M:CmdSting(alias)
+    local cfg = AutoRota:GetActiveProfile()
+    if not cfg then msgOut("no profile active.", 1, 0.5, 0.3); return end
+    local sting = self.stingAlias[string.lower(alias or "")]
+    if sting == nil then msgOut("usage: /ar sting serpent|scorpid|viper|none", 1, 0.5, 0.3); return end
+    cfg.sting = sting
+    msgOut("sting = " .. ((sting == "") and "(none)" or sting) .. ".")
+end
+
+function M:CmdAoe()
+    local cfg = AutoRota:GetActiveProfile()
+    if not cfg then msgOut("no profile active.", 1, 0.5, 0.3); return end
+    cfg.aoeMode = not cfg.aoeMode
+    msgOut("AoE mode " .. (cfg.aoeMode and "on (Volley + Multi-Shot)" or "off (single target)") .. ".")
+end
+
+function M:CmdCd(mode)
+    local cfg = AutoRota:GetActiveProfile()
+    if not cfg then msgOut("no profile active.", 1, 0.5, 0.3); return end
+    mode = string.lower(mode or "")
+    if mode == "on" or mode == "always" then
+        cfg.popCDs = true;  cfg.autoCDElite = false
+        msgOut("cooldowns: always pop.")
+    elseif mode == "elite" or mode == "boss" then
+        cfg.popCDs = false; cfg.autoCDElite = true
+        msgOut("cooldowns: auto on elite and boss only.")
+    elseif mode == "off" or mode == "manual" or mode == "none" then
+        cfg.popCDs = false; cfg.autoCDElite = false
+        msgOut("cooldowns: manual (off).")
+    else
+        msgOut("usage: /ar cd on | elite | off", 1, 0.5, 0.3)
+    end
+end
+
+function M:CmdSpell(alias, onoff)
+    local cfg = AutoRota:GetActiveProfile()
+    if not cfg then msgOut("no profile active.", 1, 0.5, 0.3); return end
+    local key = self.spellAlias[string.lower(alias or "")]
+    if not key then msgOut("unknown spell alias.", 1, 0.5, 0.3); return end
+    cfg[key] = (string.lower(onoff or "") == "on")
+    msgOut(key .. " = " .. (cfg[key] and "on" or "off") .. " (active profile).")
+end
+
+function M:HandleCommand(cmd, t)
+    if cmd == "sting" then self:CmdSting(t[2]); return true end
+    if cmd == "aoe"   then self:CmdAoe(); return true end
+    if cmd == "cd"    then self:CmdCd(t[2]); return true end
+    if cmd == "spell" then self:CmdSpell(t[2], t[3]); return true end
+    return false
+end
+
+-- ============================================================
+-- Auto Shot state reset: leaving combat stops Auto Shot, so clear the
+-- assumed-on flag and let the next pull restart it cleanly.
+-- ============================================================
+local hunterFrame = CreateFrame("Frame")
+hunterFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+hunterFrame:SetScript("OnEvent", function()
+    M.autoShotOn = false
+    M.autoShotTarget = nil
+end)

--- a/classes/Class_Hunter_UI.lua
+++ b/classes/Class_Hunter_UI.lua
@@ -1,0 +1,125 @@
+-- ============================================================
+-- Class_Hunter_UI  -  hunter window body for AutoRota
+-- Builds and binds only the hunter specific controls. The shared
+-- window shell and profile management live in AutoRota_UI.lua.
+-- ============================================================
+
+local M = AutoRota.classes.HUNTER
+
+-- ============================================================
+-- build body (hunter controls)
+-- ============================================================
+function M:BuildBody(ui, f)
+    -- Shots & Stings
+    ui:FS(f, "GameFontNormal", "Shots & Stings"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -142)
+    ui:FS(f, "GameFontNormalSmall", "Sting"):SetPoint("TOPLEFT", f, "TOPLEFT", 24, -168)
+    self.stingDD = ui:CreateDropdown("sting", f, 200, function(v) if ui.buf then ui.buf.sting = v; ui:Refresh() end end)
+    self.stingDD:SetPoint("TOPLEFT", f, "TOPLEFT", 110, -166)
+    self.markCB = ui:CreateCheck("useHuntersMark", f, "Keep Hunter's Mark up", "Hunter's Mark", function(on) if ui.buf then ui.buf.useHuntersMark = on; ui:Refresh() end end)
+    self.markCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -192)
+
+    -- Shots
+    ui:FS(f, "GameFontNormal", "Shots"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -226)
+    self.arcaneCB = ui:CreateCheck("useArcaneShot", f, "Arcane Shot", "Arcane Shot", function(on) if ui.buf then ui.buf.useArcaneShot = on; ui:Refresh() end end)
+    self.arcaneCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -248)
+    self.multiCB = ui:CreateCheck("useMultiShot", f, "Multi-Shot", "Multi-Shot", function(on) if ui.buf then ui.buf.useMultiShot = on; ui:Refresh() end end)
+    self.multiCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 200, -248)
+    self.aimedCB = ui:CreateCheck("useAimedShot", f, "Aimed Shot (cast)", "Aimed Shot", function(on) if ui.buf then ui.buf.useAimedShot = on; ui:Refresh() end end)
+    self.aimedCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -272)
+
+    -- AoE
+    ui:FS(f, "GameFontNormal", "AoE (manual toggle, /ar aoe)"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -306)
+    self.volleyCB = ui:CreateCheck("useVolley", f, "Volley leads AoE", "Volley", function(on) if ui.buf then ui.buf.useVolley = on; ui:Refresh() end end)
+    self.volleyCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -328)
+
+    -- Aspect & Pet
+    ui:FS(f, "GameFontNormal", "Aspect & Pet"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -362)
+    self.aspectCB = ui:CreateCheck("useAspectHawk", f, "Keep Aspect of the Hawk up", "Aspect of the Hawk", function(on) if ui.buf then ui.buf.useAspectHawk = on; ui:Refresh() end end)
+    self.aspectCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -384)
+    self.petCB = ui:CreateCheck("petAttack", f, "Send pet to attack", nil, function(on) if ui.buf then ui.buf.petAttack = on; ui:Refresh() end end)
+    self.petCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -408)
+    self.mendCB = ui:CreateCheck("useMendPet", f, "Mend Pet when hurt", "Mend Pet", function(on) if ui.buf then ui.buf.useMendPet = on; ui:Refresh() end end)
+    self.mendCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 200, -408)
+    self.mendSlider = ui:CreateSlider("mendPetHp", f, "Mend Pet below", function(v) if ui.buf then ui.buf.mendPetHp = v; ui:Refresh() end end)
+    self.mendSlider:SetPoint("TOPLEFT", f, "TOPLEFT", 28, -450)
+
+    -- Melee weave
+    ui:FS(f, "GameFontNormal", "Melee weave"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -484)
+    self.raptorCB = ui:CreateCheck("useRaptorStrike", f, "Raptor Strike in melee range", "Raptor Strike", function(on) if ui.buf then ui.buf.useRaptorStrike = on; ui:Refresh() end end)
+    self.raptorCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -506)
+
+    -- Cooldowns
+    ui:FS(f, "GameFontNormal", "Cooldowns"):SetPoint("TOPLEFT", f, "TOPLEFT", 20, -540)
+    self.cdCB = ui:CreateCheck("popCDs", f, "Always pop cooldowns", nil, function(on) if ui.buf then ui.buf.popCDs = on; ui:Refresh() end end)
+    self.cdCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 22, -562)
+    self.cdEliteCB = ui:CreateCheck("autoCDElite", f, "Auto on elite and boss", nil, function(on) if ui.buf then ui.buf.autoCDElite = on; ui:Refresh() end end)
+    self.cdEliteCB.cb:SetPoint("TOPLEFT", f, "TOPLEFT", 200, -562)
+
+    ui:Divider(f, -134)   -- above Shots & Stings
+    ui:Divider(f, -218)   -- above Shots
+    ui:Divider(f, -298)   -- above AoE
+    ui:Divider(f, -354)   -- above Aspect & Pet
+    ui:Divider(f, -476)   -- above Melee weave
+    ui:Divider(f, -532)   -- above Cooldowns
+
+    ui:Tip(self.stingDD, "Sting", "The one sting kept up on the target. Serpent is the staple DoT; Scorpid lowers melee hit; Viper drains mana.")
+    ui:Tip(self.markCB.cb, "Hunter's Mark", "Applied once per target and refreshed when it falls off (exact upkeep with SuperWoW).")
+    ui:Tip(self.arcaneCB.cb, "Arcane Shot", "Instant nuke, fired on cooldown between Auto Shots.")
+    ui:Tip(self.multiCB.cb, "Multi-Shot", "Fired on cooldown. Also leads AoE alongside Volley.")
+    ui:Tip(self.aimedCB.cb, "Aimed Shot", "Marksmanship cast. Queued through SuperWoW so it does not clip the current shot.")
+    ui:Tip(self.volleyCB.cb, "Volley", "When AoE mode is on, Volley channels first, then Multi-Shot fills.", "Toggle AoE with /ar aoe; 1.12 cannot count nearby enemies.")
+    ui:Tip(self.aspectCB.cb, "Aspect of the Hawk", "Recast whenever the buff is missing.")
+    ui:Tip(self.petCB.cb, "Pet attack", "Sends your pet onto the target each press.")
+    ui:Tip(self.mendCB.cb, "Mend Pet", "Heals the pet when it drops below the slider value (HoT, refreshed every ~12s).")
+    ui:Tip(self.mendSlider, "Mend Pet below", "Pet health percent under which Mend Pet is cast.")
+    ui:Tip(self.raptorCB.cb, "Raptor Strike", "When the target is in melee range, start melee swings and use Raptor Strike so a mob in your face still takes hits.")
+    ui:Tip(self.cdCB.cb, "Pop cooldowns", "Use Rapid Fire (and Bestial Wrath when known) every press.")
+    ui:Tip(self.cdEliteCB.cb, "Auto on elite", "Pop the cooldowns only against elite and boss targets.")
+end
+
+-- ============================================================
+-- refresh body (hunter binding)
+-- ============================================================
+function M:RefreshBody(ui, buf)
+    -- sting dropdown: None plus the stings the hunter actually knows
+    local o = { { label = "None", value = "" } }
+    local avail = self:AvailableStingsOf()
+    for i = 1, table.getn(avail) do o[i + 1] = { label = avail[i], value = avail[i] } end
+    local cur = buf.sting or ""
+    local shown, c
+    if cur == "" then shown, c = "None", ui.COL.white
+    elseif self:KnowsSpell(cur) then shown, c = cur, ui.COL.white
+    else shown, c = cur .. " (not learned)", ui.COL.red end
+    ui:SetDropdown(self.stingDD, o, cur, shown, c)
+
+    ui:BindCheck(self.markCB, buf.useHuntersMark)
+    ui:BindCheck(self.arcaneCB, buf.useArcaneShot)
+    ui:BindCheck(self.multiCB, buf.useMultiShot)
+    ui:BindCheck(self.aimedCB, buf.useAimedShot)
+    ui:BindCheck(self.volleyCB, buf.useVolley)
+    ui:BindCheck(self.aspectCB, buf.useAspectHawk)
+    ui:BindCheck(self.petCB, buf.petAttack)
+    ui:BindCheck(self.mendCB, buf.useMendPet)
+    ui:BindCheck(self.raptorCB, buf.useRaptorStrike)
+    ui:BindCheck(self.cdCB, buf.popCDs)
+    ui:BindCheck(self.cdEliteCB, buf.autoCDElite)
+
+    -- Mend Pet threshold slider follows the Mend Pet checkbox.
+    local mhp = buf.mendPetHp or 50
+    self.mendSlider:SetValue(mhp)
+    if self.mendSlider.valText then self.mendSlider.valText:SetText(mhp .. "%") end
+    if buf.useMendPet then
+        self.mendSlider:EnableMouse(true);  self.mendSlider:SetAlpha(1)
+    else
+        self.mendSlider:EnableMouse(false); self.mendSlider:SetAlpha(0.35)
+    end
+end
+
+-- Open the shared window for this class.
+M.OpenConfig = function(mod)
+    if not AutoRotaUI then
+        AutoRota:Throttle("UI framework not loaded. AutoRota_UI.lua is missing or mislabeled in your AutoRota folder, reinstall the files.")
+        return
+    end
+    AutoRotaUI:Toggle()
+end

--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -43,7 +43,16 @@ local DOWNRANK = {
 local TALENT_HOLY_MIGHT = "Vengeful Strike"
 local TALENT_THREAT     = "Righteous Strike"
 
--- Judgement debuff detection (texture fragment on the TARGET)
+-- Judgement debuff detection. The exact debuff name (resolved through
+-- SuperWoW spell ids) is matched first; the icon fragment is the fallback for
+-- clients without SuperWoW. A seal applies a judgement debuff of a different
+-- name, so the seal -> judgement-name map is kept alongside the textures.
+M.debuffName = {
+    ["Seal of Wisdom"]       = "Judgement of Wisdom",
+    ["Seal of the Crusader"] = "Judgement of the Crusader",
+    ["Seal of Light"]        = "Judgement of Light",
+    ["Seal of Justice"]      = "Judgement of Justice",
+}
 M.debuffTex = {
     ["Seal of Wisdom"]       = "RighteousnessAura",  -- Judgement of Wisdom
     ["Seal of the Crusader"] = "HolySmite",          -- Judgement of the Crusader
@@ -181,13 +190,10 @@ function M:ProfileValidity(cfg)
 end
 
 function M:TargetHasJudgementDebuff(sealName)
+    local nm   = self.debuffName[sealName]
     local frag = self.debuffTex[sealName]
-    if not frag or frag == "" then return false end
-    for i = 1, 40 do
-        local t = UnitDebuff("target", i)
-        if t and string.find(t, frag) then return true end
-    end
-    return false
+    if not nm and (not frag or frag == "") then return false end
+    return self:TargetDebuffUp(nm, frag)
 end
 
 -- ============================================================

--- a/classes/Class_Warlock.lua
+++ b/classes/Class_Warlock.lua
@@ -147,11 +147,7 @@ end
 
 function M:TargetHasTexture(frag)
     if not frag or frag == "" then return false end
-    for i = 1, 40 do
-        local t = UnitDebuff("target", i)
-        if t and string.find(t, frag) then return true end
-    end
-    return false
+    return self:TargetDebuffUp(nil, frag)
 end
 
 function M:CurseTex(name)
@@ -165,17 +161,20 @@ M.dotThrottle = {}
 --   "up"   the effect is present (or assumed present within its interval)
 --   "cast" a cast was queued this press
 --   "wait" recently cast and still landing, do nothing further this press
--- With a known texture, missing-but-recent counts as "wait" (let it land).
--- Without a texture, recent counts as "up" so the rotation moves on and
--- the effect is simply reapplied once the interval elapses.
+-- Detection prefers the exact spell name (SuperWoW id path), then the icon
+-- fragment. When the effect is detectable (a texture is known, or SuperWoW can
+-- resolve names), missing-but-recent counts as "wait" so the cast is allowed to
+-- land before re-queuing. Otherwise recent counts as "up" and the effect is
+-- simply reapplied on the interval, the old texture-less blind-timer path.
 function M:ApplyDot(spellName, texFrag, interval)
     interval = interval or 3
-    if texFrag and self:TargetHasTexture(texFrag) then return "up" end
+    if self:TargetDebuffUp(spellName, texFrag) then return "up" end
+    local detectable = (texFrag ~= nil) or AutoRota:CanResolveDebuffNames()
     local id = self:TargetId()
     local rec = self.dotThrottle[spellName]
     local now = GetTime()
     if rec and rec.id == id and rec.t and (now - rec.t) <= interval then
-        if texFrag then return "wait" else return "up" end
+        if detectable then return "wait" else return "up" end
     end
     self.dotThrottle[spellName] = { id = id, t = now }
     self:Queue(spellName)
@@ -201,7 +200,11 @@ function M:Rotate(cfg)
     if cfg.useImmolate then table.insert(order, { "Immolate", self.dotTex["Immolate"], 3 }) end
     if cfg.curse ~= "" then
         local tex = self:CurseTex(cfg.curse)
-        table.insert(order, { cfg.curse, tex, tex and 3 or 20 })
+        -- Exact upkeep when the curse is detectable (known icon, or SuperWoW
+        -- name resolution); only a curse we cannot see at all falls back to the
+        -- 20s blind reapply timer.
+        local detectable = tex or AutoRota:CanResolveDebuffNames()
+        table.insert(order, { cfg.curse, tex, detectable and 3 or 20 })
     end
     if cfg.useCorruption then table.insert(order, { "Corruption", self.dotTex["Corruption"], 3 }) end
     if cfg.useSiphonLife then table.insert(order, { "Siphon Life", self.dotTex["Siphon Life"], 3 }) end

--- a/classes/Class_Warrior.lua
+++ b/classes/Class_Warrior.lua
@@ -259,13 +259,9 @@ end
 -- Sunder Armor stack tracking on the target
 -- ============================================================
 function M:SunderStacksOnTarget()
-    for i = 1, 40 do
-        local tex, stacks = UnitDebuff("target", i)
-        if tex and string.find(tex, "Sunder") then
-            return stacks or 1
-        end
-    end
-    return 0
+    -- Exact name match first (SuperWoW id path), "Sunder" icon fragment as the
+    -- fallback. The snapshot carries the application count on either path.
+    return self:TargetDebuffStacks("Sunder Armor", "Sunder")
 end
 
 function M:NeedSunder(cfg)


### PR DESCRIPTION
Adds the sixth class module (Hunter): a ranged-priority engine around
Auto Shot upkeep, one sting slot, Hunter's Mark, Arcane/Multi/Aimed Shot,
optional melee weave with Raptor Strike, pet attack + Mend Pet, and the
shared three-state cooldown automation, plus its config panel and four
templates.

Replaces icon-texture-fragment target debuff detection with exact
SuperWoW spell-id name resolution, built once per press into a shared
core snapshot. Texture matching is kept as an automatic fallback for
clients without SuperWoW, so behaviour degrades rather than breaks. This
makes upkeep exact across all classes and lets the Warlock track every
curse precisely instead of blind-timer reapplying ones without a
hand-verified icon. /ar debug now prints debuff name / stacks / texture.