### PR TITLE
Paladin heal tuning, Rogue Surprise Attack (audit R1), rotations.md (R1-R5)

### DIFF
--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -161,7 +161,7 @@ M.templates = {
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "autodps",
         spells = { holyStrike = false, crusaderStrike = false, holyShield = false, hammerOfWrath = false, repentance = false },
-        healMode = true, healThreshold = 90, useHolyShock = true, holyShockPct = 50, healPower = 0,
+        healMode = true, healThreshold = 75, useHolyShock = true, holyShockPct = 50, healPower = 0,
         healWeaveManaFloor = 40, healReloadCS = true, healSplashHS = true,
         healManaSelf = true, healManaJudge = false,
     },
@@ -251,7 +251,7 @@ function M:NormalizeProfile(c)
     -- Coerce to a strict boolean. This also repairs any profile corrupted by the
     -- old tab bug, which could store the string "damage" (truthy) into healMode.
     c.healMode = (c.healMode == true)
-    if c.healThreshold == nil then c.healThreshold = 90 end
+    if c.healThreshold == nil then c.healThreshold = 75 end
     if c.useHolyShock == nil then c.useHolyShock = true end
     if c.holyShockPct == nil then c.holyShockPct = 50 end
     -- Split the old single heal-weave toggle into two independent behaviours
@@ -604,16 +604,25 @@ end
 -- ============================================================
 
 -- Record an in-flight heal so the next press does not pile onto the same unit.
+-- Also stamps their real HP at commit time (see PendingFor).
 function M:CommitHeal(unit, amount, castTime)
     self.healTarget = UnitName(unit)
     self.healAmount = amount or 0
     self.healUntil = GetTime() + (castTime or 0) + 1.0
+    self.healBaseline = UnitHealth(unit)
 end
 
--- Predicted incoming heal for a unit from our own pending cast, else 0.
+-- Predicted incoming heal for a unit from our own pending cast, else 0. Only
+-- trusted while their REAL health hasn't dropped below what it was at commit
+-- time - otherwise new damage landed after the heal was queued, and letting
+-- the stale prediction pad WorstHurt's health estimate back up would mask a
+-- fresh crisis for the rest of the cast (up to ~castTime + 1s) instead of
+-- reacting to it immediately.
 function M:PendingFor(unit)
     if self.healTarget and GetTime() < self.healUntil and UnitName(unit) == self.healTarget then
-        return self.healAmount
+        if UnitHealth(unit) >= (self.healBaseline or 0) then
+            return self.healAmount
+        end
     end
     return 0
 end
@@ -664,7 +673,7 @@ end
 -- and keeps a Seal of Wisdom judgement from stealing the global cooldown.
 function M:HealDemand(cfg)
     if self.healUntil and GetTime() < self.healUntil then return true end
-    local ratio = (cfg.healThreshold or 90) / 100
+    local ratio = (cfg.healThreshold or 75) / 100
     local units = self:GroupUnits()
     for i = 1, table.getn(units) do
         local u = units[i]
@@ -757,7 +766,7 @@ end
 -- target is below the emergency line, where Flash of Light's faster cast
 -- stays the safer bet even if it cannot fully cover the deficit.
 function M:DoHeal(cfg)
-    local ratio = (cfg.healThreshold or 90) / 100
+    local ratio = (cfg.healThreshold or 75) / 100
     local unit, deficit, pct = self:WorstHurt(ratio)
     if not unit then return false end
 
@@ -882,7 +891,7 @@ function M:HealStrikeEngine(cfg)
     if not self:BlessedReloadUsable() then return false end
     if self:OwnCDReady("Holy Shock") then return false end          -- already loaded
     if not self:IsReady("Crusader Strike") then return false end
-    local _, _, pct = self:WorstHurt((cfg.healThreshold or 90) / 100)
+    local _, _, pct = self:WorstHurt((cfg.healThreshold or 75) / 100)
     if pct and pct <= (cfg.holyShockPct or 50) / 100 then return false end
     if not self:HealMeleeReady(cfg) then return false end
     return self:CastStrike("Crusader Strike", cfg)
@@ -895,6 +904,11 @@ end
 function M:HealWeaveStrike(cfg)
     if not cfg.healSplashHS then return false end
     if not self:HealMeleeReady(cfg) then return false end
+    -- Only worth the GCD if someone actually has a scratch to top off - by the
+    -- time this runs, HealStrikeEngine/DoHeal/HealDemand have already ruled out
+    -- anyone below the priority threshold, but a fully-topped group (everyone at
+    -- 100%) would otherwise still eat a splash cast for pure overheal.
+    if not self:WorstHurt(1.0) then return false end
     local maxm = UnitManaMax("player")
     if not maxm or maxm == 0 then return false end
     if UnitMana("player") / maxm * 100 < (cfg.healWeaveManaFloor or 40) then return false end

--- a/classes/Class_Paladin_UI.lua
+++ b/classes/Class_Paladin_UI.lua
@@ -229,7 +229,7 @@ function M:RefreshBody(ui, buf)
     self.hpHighRow.slider:SetValue(buf.hpHigh or 0); self.hpHighRow.slider.valText:SetText((buf.hpHigh or 0) .. "%")
 
     -- Healing section
-    self.healAtRow.slider:SetValue(buf.healThreshold or 90); self.healAtRow.slider.valText:SetText((buf.healThreshold or 90) .. "%")
+    self.healAtRow.slider:SetValue(buf.healThreshold or 75); self.healAtRow.slider.valText:SetText((buf.healThreshold or 75) .. "%")
     -- Holy Shock emergencies. The stored preference defaults on so it just works
     -- the moment Holy Shock is trained; but while the spell is not learned the
     -- toggle is shown OFF (not a misleading lit "on") and greyed. The saved value

--- a/classes/Class_Rogue.lua
+++ b/classes/Class_Rogue.lua
@@ -10,6 +10,12 @@
 --    Eviscerate above that, mirroring the proven ExAutoRogue logic.
 --  * Eviscerate is the finisher once combo points reach the threshold.
 --  * Riposte fires inside the parry window when learned and enabled.
+--  * Surprise Attack fires inside the target's dodge window when learned and
+--    enabled - a Combat capstone (20 Combat points), the mirror image of
+--    Riposte: it reacts to the TARGET dodging OUR attack rather than us
+--    parrying theirs. Guaranteed hit (unblockable/undodgeable/unparryable),
+--    cheap (10 energy), and awards a combo point, so it is worth interrupting
+--    the normal builder/finisher flow for whenever the window is open.
 --  * Adrenaline Rush and Blade Flurry are off-GCD, cast on demand or
 --    automatically against elite and boss targets.
 -- ============================================================
@@ -36,14 +42,17 @@ M.BUILDERS = { "Sinister Strike", "Backstab", "Hemorrhage", "Noxious Assault", "
 M.templates = {
     starter = {  -- valid for any rogue, only Slice and Dice upkeep
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
+        useSurpriseAttack = false,
         cpFinish = 4, popCDs = false, autoCDElite = false,
     },
     assassination = {
         builder = "", useSnd = true, useEnvenom = true, useRupture = true, useRiposte = true,
+        useSurpriseAttack = false,
         cpFinish = 4, popCDs = false, autoCDElite = false,
     },
     combat = {
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
+        useSurpriseAttack = true,
         cpFinish = 5, popCDs = false, autoCDElite = true,
     },
 }
@@ -64,6 +73,7 @@ function M:NormalizeProfile(c)
     if c.useEnvenom == nil then c.useEnvenom = false end
     if c.useRupture == nil then c.useRupture = false end
     if c.useRiposte == nil then c.useRiposte = false end
+    if c.useSurpriseAttack == nil then c.useSurpriseAttack = false end
     if c.cpFinish == nil then c.cpFinish = 4 end
     if c.popCDs == nil then c.popCDs = false end
     if c.autoCDElite == nil then c.autoCDElite = false end
@@ -143,6 +153,7 @@ function M:Rotate(cfg)
             .. " env=" .. (useEnv and (self:SelfBuffUp("Envenom", "Sword_31") and "up" or "down") or "-")
             .. " rup=" .. (useRup and (self:TargetDebuffUp("Rupture", "Ability_Rogue_Rupture") and "up" or "down") or "-")
             .. " rip=" .. ((cfg.useRiposte and now < (self.riposteExpiry or 0)) and "Y" or "N")
+            .. " sa=" .. ((cfg.useSurpriseAttack and now < (self.surpriseExpiry or 0)) and "Y" or "N")
             .. " elite=" .. (isElite and "Y" or "N"),
             -- Rogue never downranks (all ranks cost the same energy), so every
             -- Cast() below is a bare CastSpellByName(name) - vanilla resolves
@@ -154,12 +165,22 @@ function M:Rotate(cfg)
             .. (useSnd and ("  SnD=R" .. self:MaxRank("Slice and Dice")) or "")
             .. (useEnv and ("  Envenom=R" .. self:MaxRank("Envenom")) or "")
             .. (useRup and ("  Rupture=R" .. self:MaxRank("Rupture")) or "")
-            .. ((cfg.useRiposte and self:KnowsSpell("Riposte")) and ("  Riposte=R" .. self:MaxRank("Riposte")) or ""))
+            .. ((cfg.useRiposte and self:KnowsSpell("Riposte")) and ("  Riposte=R" .. self:MaxRank("Riposte")) or "")
+            .. ((cfg.useSurpriseAttack and self:KnowsSpell("Surprise Attack")) and ("  SurpriseAttack=R" .. self:MaxRank("Surprise Attack")) or ""))
     end
 
     -- P1 Riposte, combo point independent, only inside the parry window
     if cfg.useRiposte and self:KnowsSpell("Riposte") and now < (self.riposteExpiry or 0) then
         CastSpellByName("Riposte")
+        return
+    end
+
+    -- P1b Surprise Attack, combo point independent, only inside the target's
+    -- dodge window. Guaranteed to land and cheap, so like Riposte it jumps the
+    -- normal builder/finisher queue rather than waiting its turn - missing the
+    -- window wastes the proc entirely.
+    if cfg.useSurpriseAttack and self:KnowsSpell("Surprise Attack") and now < (self.surpriseExpiry or 0) then
+        CastSpellByName("Surprise Attack")
         return
     end
 
@@ -250,6 +271,25 @@ riposteFrame:SetScript("OnEvent", function()
     if event == "CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES" then
         if arg1 and string.find(string.lower(arg1), "parry") then
             M.riposteExpiry = GetTime() + 5.5
+        end
+    end
+end)
+
+-- ============================================================
+-- Dodge window tracker for Surprise Attack - the mirror image of the parry
+-- tracker above: OUR attack getting dodged by the target, not us parrying
+-- theirs, so it listens on CHAT_MSG_COMBAT_SELF_MISSES instead. The 5.5s
+-- window length is carried over from Riposte's (audit R1: Turtle's actual
+-- Surprise Attack window is unconfirmed - verify in-game and adjust if it
+-- turns out shorter/longer, e.g. by watching how often "sa=Y" in /sbr trace
+-- goes stale before a press catches it).
+-- ============================================================
+local surpriseFrame = CreateFrame("Frame")
+surpriseFrame:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
+surpriseFrame:SetScript("OnEvent", function()
+    if event == "CHAT_MSG_COMBAT_SELF_MISSES" then
+        if arg1 and string.find(string.lower(arg1), "dodge") then
+            M.surpriseExpiry = GetTime() + 5.5
         end
     end
 end)

--- a/classes/Class_Rogue_UI.lua
+++ b/classes/Class_Rogue_UI.lua
@@ -25,6 +25,7 @@ function M:BuildBody(ui, parent)
     self.envRow = L:Row{ key = "useEnvenom", label = "Envenom", spell = "Envenom", onToggle = set("useEnvenom") }
     self.rupRow = L:Row{ key = "useRupture", label = "Rupture", spell = "Rupture", onToggle = set("useRupture") }
     self.ripRow = L:Row{ key = "useRiposte", label = "Riposte", spell = "Riposte", onToggle = set("useRiposte") }
+    self.saRow = L:Row{ key = "useSurpriseAttack", label = "Surprise Attack", spell = "Surprise Attack", onToggle = set("useSurpriseAttack") }
     self.cpRow = L:Row{ label = "Eviscerate at CP",
         slider = { key = "cpFinish", min = 1, max = 5, step = 1, suffix = "", onChange = set("cpFinish") } }
 
@@ -39,6 +40,7 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.envRow.cb, "Envenom", "Kept up the same way as Slice and Dice (Turtle ability).")
     ui:Tip(self.rupRow.cb, "Rupture", "Applied as a finisher at your combo-point threshold when it falls off the target.", "With the Assassination talent Taste for Blood, keeping it up is also a stacking damage buff.")
     ui:Tip(self.ripRow.cb, "Riposte", "Cast right after a parry, inside the short Riposte window.")
+    ui:Tip(self.saRow.cb, "Surprise Attack", "Cast right after the TARGET dodges you, inside a short window (mirror image of Riposte).", "Combat capstone (20 points). Guaranteed hit, cheap, awards a combo point.")
     ui:Tip(self.cpRow.slider, "Finisher combo points", "Eviscerate is used once combo points reach this number.")
     ui:Tip(self.cdRow.cb, "Pop cooldowns", "Use Adrenaline Rush and Blade Flurry every press (off the global cooldown).")
     ui:Tip(self.cdEliteRow.cb, "Auto on elite", "Pop the cooldowns only against elite and boss targets.")
@@ -63,6 +65,7 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.envRow, buf.useEnvenom)
     ui:BindCheck(self.rupRow, buf.useRupture)
     ui:BindCheck(self.ripRow, buf.useRiposte)
+    ui:BindCheck(self.saRow, buf.useSurpriseAttack)
     ui:BindCheck(self.cdRow, buf.popCDs)
     ui:BindCheck(self.cdEliteRow, buf.autoCDElite)
 

--- a/docs/rotations.md
+++ b/docs/rotations.md
@@ -125,14 +125,55 @@ CHANGELOG v0.14.1 and audit item H1).
 ### Combat (raid/dungeon DPS — only endgame-viable spec) `[T]`
 Sinister Strike (Improved SS baseline; Swift Strikes adds attack speed) to build combo
 points → **Slice and Dice uptime = top priority** → Rupture / Eviscerate finishers.
-- **Surprise Attack** (Combat 5th-row capstone): 120% weapon dmg, 10 energy, usable after
-  target dodges, can't be dodged/parried/blocked.
+- **Surprise Attack** (Combat capstone, 20 Combat points — Rank 1/1, in-game tooltip
+  confirmed; supersedes the earlier "120% weapon dmg" estimate below): 10 energy, instant,
+  25% of Attack Power as damage, guaranteed to land (can't be blocked/dodged/parried),
+  1 combo point. Usable only after the TARGET dodges your attack. Implemented in Aegis_SBR
+  as a reactive window mirroring Riposte's parry tracker, but on
+  `CHAT_MSG_COMBAT_SELF_MISSES` filtered for "dodge" instead of
+  `CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES` filtered for "parry" (audit R1, implemented —
+  window length carried over from Riposte's 5.5s as a placeholder, **unverified for
+  Surprise Attack specifically**; tune via `/sbr trace`'s `sa=` field if it proves too
+  short/long in practice).
 - Blade Flurry + Adrenaline Rush burst. Blade Rush scales energy-tick regen with agility.
 - Combo points no longer vanish on target switch (reset fresh). Rogues can use 1H axes.
+- **Noxious Assault does not apply here** (see Assassination below) — it requires 31
+  Assassination points, which a Combat build never has, so Aegis_SBR's auto-builder
+  preference for it over Sinister Strike is a non-issue for Combat in practice (audit R3).
+- **Slice and Dice 1-CP cheap-refresh model, resolved (audit R2)**: Aegis_SBR only refreshes
+  SnD immediately when combo points happen to be exactly 1 (otherwise it dumps into
+  Eviscerate first and catches the refresh on a later pass) — cheap on combo points, but in
+  theory risks a brief SnD downtime gap while waiting to cycle back to 1cp. **Ruthlessness**
+  (Assassination, 6-8 points, 3/3 = 100% chance, in-game tooltip confirmed: "finishing moves
+  have a 100% chance to add a combo point to your target") closes that gap in practice: every
+  finisher (Eviscerate included) immediately regenerates to exactly 1 combo point, so the
+  cheap-refresh window recurs on the very next press after every single finisher, not after
+  several builder hits. Since Ruthlessness is an early, low-cost pick that most serious
+  Combat/hybrid builds take regardless of final spec, the existing model needs no change for
+  the practical case. A hypothetical 0-Assassination-point Combat rogue (rare, generally
+  suboptimal) would still see the original gap — noted, not acted on.
 
 ### Assassination `[T]` (weaker)
 Poison-focused; not endgame-competitive (Combat is the only viable PvE spec to late
 AQ40/Naxx).
+- **Noxious Assault** (Assassination end talent, 31 points — Rank 1/1, in-game tooltip
+  confirmed): 45 energy, instant, 5yd, strikes with **both** weapons for 30 + 30% AP and
+  **guarantees** poison application from both weapons; 1 combo point. Compare **Sinister
+  Strike** R6 (lvl 46, tooltip confirmed): 40 energy, instant, main-hand only, +33 flat on
+  top of melee damage, normal (non-guaranteed) poison proc chance; 1 combo point.
+  Despite costing 5 more energy, Noxious Assault wins on total value whenever poisons are
+  applied — a full second weapon hit plus two guaranteed procs (vs. one chance-based proc)
+  outweighs the energy premium. Confirms Aegis_SBR's auto-builder (prefers Noxious Assault
+  whenever known, else Sinister Strike) is correct; the 31-point requirement means this only
+  ever applies to a deep/pure Assassination build, matching the module's own "Assassination
+  flavoured" design intent (audit R3, resolved — no code change).
+- **Envenom** (Assassination talent, ~21 points deep — Rank 1/1, in-game tooltip confirmed):
+  20 energy, instant, **finisher** (consumes combo points, not a builder). Self-buff: +30%
+  poison effectiveness and +30% poison application chance on the rogue. Duration scales by
+  combo points spent at cast: 1cp=12s, 2cp=16s, 3cp=20s, 4cp=24s, 5cp=28s — matches
+  Aegis_SBR's `ENV_DUR = {12, 16, 20, 24, 28}` exactly. Confirms the code's model (self-buff
+  refreshed cheaply at 1 combo point, dumped into Eviscerate above that, mirroring the
+  Slice-and-Dice upkeep pattern) is correct (audit R4, resolved — no code change).
 
 ### Subtlety (dungeon support) `[T]` (niche)
 Ambush/Backstab; Honor Among Thieves (party crits → 5 energy); Cloaked in Shadows party
@@ -141,6 +182,21 @@ damage bubble via low-CD Vanish (Elusiveness); Serrated Blades garrote.
 ### Leveling `[T]`
 Combat (swords or daggers). Dagger: Ambush → Gouge → pool energy → Backstab →
 Eviscerate/Rupture; kite with Crippling Poison + Rupture.
+
+### ⏸ Deferred (audit R5): no stealth opener `[?]`
+Aegis_SBR's rotation never checks for Stealth — it starts straight at the normal builder
+even when opening from stealth, so an Ambush-type opener is left on the table. Confirmed
+**not worth adding for the two specs the addon actually targets**: Assassination (dagger)
+already out-damages a stealth opener with Noxious Assault + its guaranteed double poison
+proc (audit R3), and Combat (sword/axe) can't cast Ambush at all (dagger-only requirement).
+The remaining case — a Subtlety or dagger-leveling player who wants a proper stealth-opener
+weave (Ambush, optionally Gouge → energy-pool → Backstab per the Leveling line above) —
+is real but **deliberately deferred**: neither maintainer currently plays Combat or
+Subtlety, so a design (energy pooling? which opener?) can't be validated in-game right now.
+Sketch discussed and available if someone picks this up: a toggle gated on a Stealth-buff
+check (mirrors the existing `SelfBuffUp` helper), Ambush as priority 0 before Riposte, no
+pooling logic initially. **Not implemented — pick this back up only with someone able to
+test a Combat or Subtlety build.**
 
 ### PvP/defensive (Phase 4, note only)
 Vanish, Blind, Evasion, Cloak, Kidney Shot, Improved Gouge.


### PR DESCRIPTION
## Summary
**Paladin**
- Fix: in-flight heal prediction (`CommitHeal`/`PendingFor`) could mask fresh burst damage on a target for up to ~cast time + 1s, since the predicted heal amount was trusted blindly even if the target's real HP had since dropped. Found in-game: a tank crashing to 30% HP over 4-5s went unhealed despite >90% mana. Now the prediction is only trusted while the target's real HP hasn't fallen below what it was at commit time.
- `HealWeaveStrike` (Holy Strike filler) now requires `WorstHurt(1.0)` to find someone actually below 100% HP, so a fully-topped group no longer eats a pure-overheal filler cast.
- Default `healThreshold` lowered 90 → 75 (template + all fallbacks + UI display) — 90 was healing too eagerly and burning mana fast for newcomers. Only affects new/unset profiles.

**Rogue — audit R1 implemented**
- New Surprise Attack support: reactive Combat capstone, fires in the window opened by the target dodging our attack (mirror image of the existing Riposte parry tracker). New `useSurpriseAttack` toggle (on by default in the `combat` template), UI checkbox, `sa=` trace field. Window length (5.5s, carried over from Riposte) is an **unverified placeholder** — needs in-game tuning.

**docs/rotations.md — Phase 1 audit follow-up, in-game tooltip confirmed this session**
- R1 (Surprise Attack): corrected "120% weapon dmg" estimate → confirmed 25% AP; documented as implemented.
- R2 (SnD 1-CP refresh model): resolved — Ruthlessness (100% at 3/3, Assassination 6-8 pts) regenerates 1 combo point on every finisher, so the cheap-refresh window recurs after every finisher. No change needed for the common case.
- R3 (Noxious Assault): resolved — tooltip-confirmed 45 energy/both weapons/guaranteed double poison proc beats Sinister Strike's 40 energy/main-hand/chance-based proc. Requires 31 Assassination points, so never conflicts with a Combat build.
- R4 (Envenom): resolved — tooltip-confirmed 20-energy finisher/self-buff, duration table matches `ENV_DUR` exactly.
- R5 (stealth opener): deferred, documented, not implemented. Not worth it for Assassination (NA already beats an Ambush opener) or Combat (can't cast Ambush — dagger-only); would only help Subtlety/dagger-leveling, which neither of us currently plays.

## Test plan
- [ ] `python scripts/verify.py --all` — all files pass (balance + ordering), confirmed before this PR.
- [ ] In-game: reproduce the original bug — let a tank take burst damage shortly after committing a heal on them, confirm the paladin now reacts immediately instead of stalling ~cast-time+1s.
- [ ] In-game: fully heal a group, confirm Holy Strike filler no longer fires at 100% group HP.
- [ ] In-game: Combat-spec rogue with Surprise Attack talented, confirm it fires after a target dodge and check via `/sbr trace`'s `sa=` field whether the 5.5s window feels right (too eager / expires too soon).
- [ ] Existing paladin profiles: confirm `healThreshold` did NOT change for already-saved profiles (only affects new ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)