### PR TITLE
Dependency refresh: SuperWoW verified through 2.2 (Command 1, SuperWo…

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -4,7 +4,7 @@ Aegis_SBR is built on three client mods. This documents what each one actually p
 APIs, events, behaviors, and gotchas — so rotation code targets them correctly instead of
 assuming vanilla or retail behavior. **Verify against the versions actually installed on the
 user's client**; all three projects have moved forks and changed APIs over time (notes
-below). Last researched: 2026.
+below). Last researched: 2026-07-17 (SuperWoW refreshed through 2.2).
 
 ---
 
@@ -20,16 +20,24 @@ metadata. This is the backbone of Aegis's targeting and cast detection.
   cast at a specific unit/GUID without targeting it. Core to acting on off-target units.
 - **`UNIT_CASTEVENT`** — fires on cast activity for any unit. Args (1.12 globals):
   `arg1` = caster GUID, `arg2` = target GUID, `arg3` = event type
-  (`"START"` / `"CAST"` / `"CHANNEL"` / `"FAIL"` etc.), `arg4` = spell ID,
+  (`"START"` / `"CAST"` / `"CHANNEL"` / `"FAIL"`, plus **`"MAINHAND"` / `"OFFHAND"` for
+  auto-attack swings** — Features wiki, verified 2026-07-17), `arg4` = spell ID,
   `arg5` = cast duration (ms). Aegis registers this and dispatches `"CAST"` events to the
   active module's `OnCastEvent(caster, target, spellName)` after resolving the ID → name
   via `SpellInfo`. (Used today for Shaman totem-drop tracking; the basis for future
-  interrupt/defensive detection.)
-- **`SpellInfo(spellID)`** → returns spell name (and more). Aegis uses it to turn the
-  `UNIT_CASTEVENT` numeric spell ID into a name for matching.
+  interrupt/defensive detection.) ⭐ **The swing events are rotation-relevant:** an exact
+  event-driven swing timer could replace the combat-log text parsing behind seal twisting
+  and on-next-swing windows (audit items P8 / W6) — verify they fire on Turtle's bundled
+  build first; any adoption that changes ability timing goes through the audit gate.
+- **`SpellInfo(spellID)`** → per the Features wiki returns **name, rank, texture file, and
+  min/max range to the target** (verified 2026-07-17). Aegis currently uses only the name
+  (ID → name for `UNIT_CASTEVENT` matching); the range returns are a future option for
+  range gating without `CheckInteractDistance`.
 - **Combat-log / owner tagging** — SuperWoW exposes the owner of pets/totems/guardians in
   combat-log context, which is what makes **totem destruction detection** feasible
   (roadmap Phase 2): tag a totem's GUID on cast, watch for its death with owner = player.
+  A **`RAW_COMBATLOG`** event (raw versions of all combat-log events; Features wiki) exists
+  as a lower-level hook if the parsed log proves lossy for that detection.
 
 **Gotchas:**
 - GUIDs are large numbers — be careful never to compare them as truncated Lua numbers where
@@ -47,10 +55,10 @@ own SuperWoW build and the number may not track upstream exactly. Aegis targets 
 1.18.1's bundled SuperWoW; **confirm which functions actually exist on the live client before
 relying on them.**
 
-**Version history relevant to Aegis** (from the SuperWoW wiki Changelog; 2.1 is user-provided
-and not yet independently confirmed against the wiki as of this writing):
+**Version history relevant to Aegis** (from the SuperWoW wiki Changelog, re-verified
+**2026-07-17**; the wiki's newest entry is **2.2, 16/07/2026**):
 
-*2.0 (July 2026) — confirmed from wiki Changelog:*
+*2.0 (10/07/2026) — confirmed from wiki Changelog:*
 - `CastSpellByName(spell, "CLICK")` — second arg `"CLICK"` instantly casts a reticle/ground
   spell at the mouseover location, bypassing the targeting-circle step. (Useful later for
   ground-targeted totems/traps/AoE without a manual click — but a rotation change, so gated.)
@@ -67,7 +75,8 @@ and not yet independently confirmed against the wiki as of this writing):
 - Nameplate/chat-bubble CVars (`NameplateRange`, `NameplateMotion` 0/1/2, `ChatBubbleRange`,
   `HealingText`, etc.) and `CREATE_CHATBUBBLE` event. (Not combat-relevant.)
 
-*2.1 (15/07/2026) — USER-PROVIDED (record, verify on client before use):*
+*2.1 (15/07/2026) — wiki-CONFIRMED 2026-07-17 (matches the earlier user-provided notes;
+still presence-gate every function on Turtle's bundled build before relying on it):*
 - **`GetWeaponEnchantID(unit)` → mainhand, offhand temporary enchant IDs.** ⭐ **This is the
   rotation-relevant one.** It lets the engine detect whether a *temporary* weapon enchant is
   currently active — Windfury/Rockbiter/Flametongue/Frostbrand imbues (Shaman), sharpening/
@@ -76,12 +85,26 @@ and not yet independently confirmed against the wiki as of this writing):
   poison-uptime awareness, Warrior/any-class stone/oil upkeep. See roadmap "Weapon-enchant
   awareness" item. Returns an ID (not a name) — Aegis would map known imbue/poison enchant IDs
   to meaning, or just test presence/change.
+- **Related, from the Features wiki (SuperWoW version not stated — confirm on client):
+  `GetWeaponEnchantInfo()` accepts a friendly player unit argument** (e.g. `"party1"`) and
+  reports the temporary enchant on that player's main/offhand — per the wiki it surfaces the
+  enchant **NAME**, which would spare Aegis the ID→meaning mapping entirely. Verify the exact
+  return values in-game before building the Phase 2 helper on it.
 - `GetSendMailItemLink()`, `GetInboxItemLink(itemIndex)` — mail item hyperlinks. (Not
   combat-relevant.)
 - `GetQuestID(questIndex)`, `GetQuestLink(questID)` — questlog ID + hyperlink (fills client
   cache from server, fires `QUEST_LOG_UPDATE` on a cache miss). Tooltip `SetHyperlink` now
-  supports quest links. (Not combat-relevant.)
+  supports quest links. (Not combat-relevant; **renamed in 2.2 — see below, use the 2.2
+  names.**)
 - NameplateMotion Smart Spread improvements.
+
+*2.2 (16/07/2026) — confirmed from wiki Changelog:*
+- NameplateMotion smart-spread improvements + a new compact spread mode. (Not
+  combat-relevant.)
+- **Quest functions refactored/renamed**: `GetQuestIDForLogIndex(questIndex)`,
+  `GetQuestLinkForLogIndex(questIndex)`, `GetQuestLinkForID(questID)` replace 2.1's
+  short-lived `GetQuestID`/`GetQuestLink`. If anything ever touches these, presence-gate
+  and prefer the 2.2 names. (Not combat-relevant.)
 
 - Feature reference: https://github.com/balakethelock/SuperWoW/wiki/Features ·
   Changelog: https://github.com/balakethelock/SuperWoW/wiki/Changelog

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -157,7 +157,9 @@ from the polish backlog if built.
   expiry timers.
 - **Heal-engine dedupe**: unify the four near-identical heal engines
   (Paladin/Priest/Druid/Shaman) into one shared module; class modules pass config in.
-- **Weapon-enchant awareness (SuperWoW 2.1 `GetWeaponEnchantID(unit)`)**: add a shared helper
+- **Weapon-enchant awareness (SuperWoW 2.1 `GetWeaponEnchantID(unit)`, wiki-confirmed
+  2026-07-17; see also `GetWeaponEnchantInfo(unit)` which per the Features wiki reports
+  enchant NAMES — details in `docs/dependencies.md`)**: add a shared helper
   that reports whether a temporary main-hand/off-hand enchant is active, so the engine can
   react to imbue/poison/oil/stone uptime. Primary targets: **Enhancement Shaman** (Windfury/
   Rockbiter/Flametongue/Frostbrand imbue upkeep), **Rogue** (poison-as-enchant uptime),

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -16,8 +16,8 @@ and don't trust the wrong source.
 | Source | Fetchable by Claude Code? | Use it for | Last verified |
 |---|---|---|---|
 | `docs/TALENTS_1_18_1.md` | ✅ It's a committed file | **Talent trees / spec talent data — THE talent source of truth** | (repo) |
-| SuperWoW **Changelog** wiki — https://github.com/balakethelock/SuperWoW/wiki/Changelog | ✅ Fetches cleanly | Dependency updates (SuperWoW versions/API) | 2026-07-15 (through 2.0; 2.1 user-provided) |
-| SuperWoW **Features** wiki — https://github.com/balakethelock/SuperWoW/wiki/Features | ✅ Fetches cleanly | Dependency API surface | 2026-07-15 |
+| SuperWoW **Changelog** wiki — https://github.com/balakethelock/SuperWoW/wiki/Changelog | ✅ Fetches cleanly | Dependency updates (SuperWoW versions/API) | 2026-07-17 (through **2.2**; the 2.1 user-provided notes are now wiki-confirmed) |
+| SuperWoW **Features** wiki — https://github.com/balakethelock/SuperWoW/wiki/Features | ✅ Fetches cleanly | Dependency API surface | 2026-07-17 (added UNIT_CASTEVENT swing types, SpellInfo extended returns, RAW_COMBATLOG, GetWeaponEnchantInfo(unit)) |
 | Nampower (avitasia fork) `SCRIPTS.md` / `EVENTS.md` — gitea.com/avitasia/nampower | ✅ Search/fetch works | Dependency updates (queue API, events) | 2026-07-15 |
 | SuperCleveRoidMacros wiki — https://github.com/jrc13245/SuperCleveRoidMacros/wiki | ✅ Fetches cleanly | Dependency updates (conditionals, reqs) | 2026-07-15 (repo archived/stable) |
 | Turtle WoW Wiki — https://turtle-wow.fandom.com | ✅ Fetches cleanly | Confirmed custom mechanics | 2026-07-15 |


### PR DESCRIPTION
…W scope)

Re-checked the SuperWoW Changelog + Features wikis (both fetch cleanly) against docs/dependencies.md:

- 2.1 (15/07/2026) is now wiki-CONFIRMED — it matches the previously user-provided notes (GetWeaponEnchantID, mail links, quest links, smart spread); the unverified flag is cleared, presence-gating advice kept.
- NEW 2.2 (16/07/2026) recorded: NameplateMotion compact spread, and the 2.1 quest functions renamed to GetQuestIDForLogIndex / GetQuestLinkForLogIndex / GetQuestLinkForID (2.1 names short-lived; prefer 2.2 names). Not combat-relevant.
- Features-wiki additions with rotation relevance flagged: UNIT_CASTEVENT also fires MAINHAND/OFFHAND swing events (candidate exact swing timer for seal twisting / on-next-swing windows — audit items P8/W6; adoption stays behind the audit gate); SpellInfo returns name, rank, texture, min/max range (Aegis uses only the name today); RAW_COMBATLOG as a lower-level hook for Phase 2 totem-death detection; GetWeaponEnchantInfo(unit) reports enchant NAMES for friendly players (version unstated - verify on client), noted beside GetWeaponEnchantID in the Phase 2 roadmap item.
- sources.md last-verified dates bumped to 2026-07-17; 2.0 dated precisely (10/07/2026).

No rotation code touched, per the Command 1 rule.


Claude-Session: https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN