### PR TITLE
Precise heal-range checks (all healers), Holy Shock range fix, Paladin audit P1-P11 closed

### DIFF
--- a/classes/Class_Druid.lua
+++ b/classes/Class_Druid.lua
@@ -574,10 +574,16 @@ function M:GroupUnits()
     return t
 end
 
--- Heal range proxy: ~28yd (the largest CheckInteractDistance band). Heals reach
--- 40yd, so this is conservative, but it keeps the picker off units it can't hit.
+-- Uses IsSpellInRange against the longest-range known heal for an exact
+-- answer instead of the old ~28yd CheckInteractDistance proxy (druid heals
+-- reach 40yd, so the proxy was under-filtering by 12yd - a hurt unit at
+-- 30-40yd could be skipped as a candidate even though Healing Touch/
+-- Rejuvenation could reach them). Falls back to the proxy only if neither
+-- heal is learned yet (very early leveling).
 function M:Reachable(u)
     if u == "player" then return true end
+    if self:KnowsSpell("Healing Touch") then return IsSpellInRange("Healing Touch", u) == 1
+    elseif self:KnowsSpell("Rejuvenation") then return IsSpellInRange("Rejuvenation", u) == 1 end
     return CheckInteractDistance(u, 4) and true or false
 end
 

--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -591,8 +591,13 @@ end
 -- Rotation. Strict single-cast priority with early returns, so exactly
 -- one spell is chosen per press. Casting more than one CastSpellByName
 -- per frame is unreliable in 1.12 (a later call overrides an earlier
--- one), which would invert the priority. The strike queues on the next
--- swing even out of range, so the swing start stays smooth.
+-- one), which would invert the priority. The strike (Holy Strike/Crusader
+-- Strike) is a plain GCD-consuming instant cast, same as Judgement below it -
+-- confirmed in-game (audit P2); it does NOT queue on the next swing the way
+-- an off-GCD ability would. Strike still leads Judgement in this priority
+-- deliberately: threat generation on the first Holy Strike matters for
+-- tanking, and Holy Might/Zeal buff upkeep matters for Retribution - both
+-- outweigh a Judgement/debuff briefly waiting one extra press.
 -- Priority: 0 pre-cast seal while running in, 1 strike, 2 Holy Shield,
 -- 2b Consecration (when AoE-toggled on), 3 seals/judgement, 4 Hammer,
 -- 5 Repentance, 6 Exorcism (undead/demon). Exorcism stays low so it never
@@ -641,9 +646,15 @@ function M:GroupUnits()
     return units
 end
 
--- Self is always reachable; others must be within heal range.
+-- Self is always reachable; others must be within heal range. Uses
+-- IsSpellInRange against the longest-range known heal (Flash of Light/Holy
+-- Light, both 40yd) for an exact answer instead of CheckInteractDistance's
+-- ~28yd proxy, which under-filtered by 12yd. Falls back to the proxy only if
+-- neither heal is learned yet (very early leveling).
 function M:Reachable(u)
     if UnitIsUnit(u, "player") then return true end
+    if self:KnowsSpell("Flash of Light") then return IsSpellInRange("Flash of Light", u) == 1
+    elseif self:KnowsSpell("Holy Light") then return IsSpellInRange("Holy Light", u) == 1 end
     return CheckInteractDistance(u, 4)
 end
 
@@ -791,10 +802,23 @@ function M:DoHeal(cfg)
     local rankDeficit = (hdb < 1) and (deficit / hdb) or deficit
 
     -- Holy Shock: instant, for an emergency or a hurt unit out of melee range.
+    -- Holy Shock's own range (20yd) is shorter than Flash of Light/Holy
+    -- Light's (40yd); IsSpellInRange gives an exact answer (the same API the
+    -- default action bar and hotbar addons use to red-tint an out-of-range
+    -- icon), so it gates the actual cast precisely - a target between 20 and
+    -- 40yd now correctly falls straight through to Flash of Light/Holy Light
+    -- below instead of wasting the press on a Holy Shock that would have
+    -- failed to reach (this was the bug: previously nothing was cast at all
+    -- for a hurt unit sitting in that 20-40yd gap).
     if cfg.useHolyShock and self:KnowsSpell("Holy Shock") and self:OwnCDReady("Holy Shock")
-        and (pct <= (cfg.holyShockPct or 50) / 100 or not CheckInteractDistance(unit, 3)) then
+        and (pct <= (cfg.holyShockPct or 50) / 100 or not CheckInteractDistance(unit, 3))
+        and IsSpellInRange("Holy Shock", unit) == 1 then
         local hs, amt = self:PickRank("Holy Shock", hsEff, self.HS_MANA, rankDeficit, mana)
-        if hs then self:CommitHeal(unit, amt * hdb, 0); self:CastOn(hs, unit); return true end
+        if hs then
+            self:CommitHeal(unit, amt * hdb, 0)
+            self:CastOn(hs, unit)
+            return true
+        end
     end
 
     -- Cast-time compensation: the target keeps losing health while the cast

--- a/classes/Class_Priest.lua
+++ b/classes/Class_Priest.lua
@@ -346,8 +346,15 @@ function M:GroupUnits()
     return units
 end
 
+-- Uses IsSpellInRange against the longest-range known heal for an exact
+-- answer instead of CheckInteractDistance's ~28yd proxy (priest heals reach
+-- 40yd, so the proxy was under-filtering by 12yd). Falls back to the proxy
+-- only if none of the probed heals are learned yet (very early leveling).
 function M:Reachable(u)
     if UnitIsUnit(u, "player") then return true end
+    if self:KnowsSpell("Heal") then return IsSpellInRange("Heal", u) == 1
+    elseif self:KnowsSpell("Flash Heal") then return IsSpellInRange("Flash Heal", u) == 1
+    elseif self:KnowsSpell("Renew") then return IsSpellInRange("Renew", u) == 1 end
     return CheckInteractDistance(u, 4)
 end
 

--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -301,10 +301,14 @@ function M:GroupUnits()
     return t
 end
 
--- Heal range proxy: ~28yd (the largest CheckInteractDistance band). Heals reach
--- 40yd, so this is conservative, but it keeps the picker off units it can't hit.
+-- Uses IsSpellInRange against the longest-range known heal for an exact
+-- answer instead of the old ~28yd CheckInteractDistance proxy (shaman heals
+-- reach 40yd, so the proxy was under-filtering by 12yd). Falls back to the
+-- proxy only if neither heal is learned yet (very early leveling).
 function M:Reachable(u)
     if u == "player" then return true end
+    if self:KnowsSpell("Healing Wave") then return IsSpellInRange("Healing Wave", u) == 1
+    elseif self:KnowsSpell("Lesser Healing Wave") then return IsSpellInRange("Lesser Healing Wave", u) == 1 end
     return CheckInteractDistance(u, 4) and true or false
 end
 

--- a/docs/rotations.md
+++ b/docs/rotations.md
@@ -56,11 +56,27 @@ intentionally removed.
 ### Retribution (raid/dungeon DPS) `[T]`
 Keep a Seal up at ALL times → Judgement on CD (respect swing timer; never white-swing
 seal-less) → **Holy Strike on CD** (mana-free; returns mana via Judgement of Wisdom) → ramp
-**Crusader Strike to 5 stacks of Zeal** → Consecration if mana allows.
+**Crusader Strike to 3 stacks of Zeal** (corrected — audit P1, resolved: in-game spell
+description confirms the Zeal buff caps at 3, not 5 as originally recorded here; matches
+Aegis_SBR's existing `ZEAL_STACKS = 3`, so no code change needed) → Consecration if mana
+allows.
 - Seal choice: **Seal of Righteousness preferred** in most cases (can trigger Windfury /
   Crusader enchants); Seal of Command for slow-weapon burst.
+- **Judgement vs. strike order (audit P2), decided — no code change.** Confirmed in-game:
+  both the strike and Judgement are plain GCD-consuming instants (the strike does not queue
+  on the next swing free of the GCD, correcting a stale code comment that assumed
+  otherwise). This makes the research's "Judgement on CD" ahead of the strike a real,
+  actionable order question, not a moot one - but the decision is to keep the strike ahead
+  of Judgement as Aegis_SBR already does: threat generation on the first Holy Strike matters
+  for Protection, and Holy Might/Zeal buff upkeep matters for Retribution, both outweighing
+  a Judgement/debuff refresh occasionally waiting one extra press.
 - Because CS + Holy Strike share the 6s CD, the practical loop is "one strike / 6s +
   Judgement + reseal."
+- **`sealTwist` default off, decided (audit P8) — no change.** The toggle (hold the damage
+  seal's Judgement until <0.4s before the next white swing, so the swing never lands
+  seal-less) is explicitly experimental and latency-sensitive - built as a trial with no
+  guarantee it actually lands correctly on a given connection, so it stays opt-in rather than
+  a safe default.
 
 ### Holy (raid/dungeon heal) `[T]` — melee-capable healer
 At range: Flash of Light spam (tank), Holy Light (big heals), Holy Shock (instant,
@@ -71,12 +87,49 @@ capstone: crit-heal leaves a 12s +20% healing-taken / +5% max-HP buff. Manage Ha
 
 ### Protection (tank/dungeon) `[T]`
 Blessing of Sanctuary → Holy Strike (free, mana return) → judge Seal of Wisdom, reseal →
-high-rank Consecration → Holy Shield on Redoubt proc → Bulwark of the Righteous (row-7
-capstone: Holy damage + 40% DR, 3-min CD).
+high-rank Consecration → Holy Shield kept up on cooldown. **Bulwark of the Righteous is
+deliberately NOT part of the automated loop** (see note below).
+- **Consecration as a single-target filler, decided (audit P4) — no code change.** Stays
+  AoE-only, manual toggle. A tank wants it held in reserve for adds appearing suddenly
+  rather than burning it as steady single-target chip damage; the damage-to-mana ratio
+  against one target doesn't justify auto-casting it there anyway.
+- **Holy Shield trigger, resolved (audit P5) — no code change.** The "Holy Shield on Redoubt
+  proc" phrasing above is corrected: in-game tooltips (135 mana, instant, 10s cooldown,
+  +45% block chance **for 10 sec** - Redoubt is a separate, independent 5-rank passive with
+  its own proc chance) show Holy Shield's own duration exactly matches its cooldown, i.e. it
+  is designed for continuous uptime, not a proc-timed hold. It is also self-sufficient
+  regardless of Redoubt: each block it grants deals 35 Holy damage with **+50% extra
+  threat**, valuable on its own merits. Aegis_SBR's existing behavior (recast on cooldown
+  whenever ready) is correct; this was the audit's highest-risk item and needed real
+  evidence before touching a tank defensive - now settled.
+- **Bulwark of the Righteous, resolved (audit P6) — no code change, deliberately not
+  automated.** In-game tooltip corrects the numbers above: 200 mana, instant, 5yd, **5 min
+  cooldown** (not 3), 274-301 Holy damage, **30% damage reduction for 12 sec** (not 40%).
+  Requires 31 Protection points (a true row-7/8 capstone, comparable depth to Noxious
+  Assault's 31 Assassination points). Decided to leave it out of the automated rotation
+  entirely: a 5-minute emergency defensive is meant for situational manual use during a
+  spike of incoming damage, a judgment call the player should make, not the rotation - the
+  same reasoning that already keeps Divine Shield/Lay on Hands/Hand of Protection manual-only
+  below.
+- **Prot seal-of-choice template default, decided (audit P7) — no template change.** Seal of
+  Wisdom (the research's suggested "core loop" seal, for group-wide mana return) isn't even
+  available before level 18, so defaulting a fresh `prot` profile to it would leave a
+  leveling tank with no seal at all until they manually switch - the current Seal of the
+  Crusader/Righteousness default works immediately at any level. On top of that, with
+  multiple paladins in a group, Seal of Wisdom coverage needs coordinating (a second paladin
+  typically runs Seal of Judgement instead of doubling up), so there is no single "correct"
+  default anyway - this is left as the already-supported manual/situational choice it is.
 
 ### Leveling `[T]`
-Seal of Command R1 + Holy Strike (free) + Judgement between autos; finish with Judgement of
-Command. Proc weapons prized.
+Seal of Command R1 + Judgement between autos; finish with Judgement of Command. Proc weapons
+prized.
+- **Pre-talent strike lean, resolved (audit P11) — no code change.** The "Holy Strike (free)"
+  leveling lean above is corrected: Zeal (via Crusader Strike) works from level 1 with zero
+  talent investment, while Holy Might (via Holy Strike) does not exist as a buff until the
+  Vengeful Strikes talent is taken - there is nothing to gain by leaning on Holy Strike before
+  that talent, since its payoff buff isn't there yet. Aegis_SBR's existing behavior (lean
+  Crusader Strike pre-talent, only start tracking Holy Might once the talent is confirmed
+  known) is correct as-is.
 
 ### PvP/defensive (Phase 4, note only)
 Divine Shield, Lay on Hands, Hand of Protection/Freedom, Repentance.


### PR DESCRIPTION
## Summary

**Bug fix — Holy Shock range gap.** Holy Shock's range (20yd) is shorter than Flash of Light/Holy Light's (40yd). `DoHeal` attempted Holy Shock whenever the emergency/out-of-melee trigger matched, with no actual range validity check — a target sitting in the 20-40yd gap got nothing cast at all that press (the attempt silently failed in-game, but the function returned as if it had succeeded, so it never fell through to a heal that could actually reach). Found via in-game reproduction. Now gated on `IsSpellInRange("Holy Shock", unit) == 1` — the same API the default action bar/hotbar addons use for range-based red-tinting.

**Bug fix — heal-candidate range filtering, all 4 healers.** `Reachable()` (Paladin/Priest/Druid/Shaman) used `CheckInteractDistance`'s coarse ~28yd band as a "can any heal reach this person" proxy. Actual heal ranges are 40yd for all four classes, so a hurt unit at 28-40yd was silently excluded from the heal-candidate pool even though a heal could reach them. Now uses `IsSpellInRange` against the longest-range known heal, falling back to the old proxy only if no heal is learned yet.

**Paladin Phase 1 audit — all 11 items (P1-P11) resolved or explicitly decided.** Verified via in-game tooltip screenshots and maintainer judgment calls; full reasoning per item recorded in `docs/rotations.md`. No rotation code changed as a result of the audit itself — every item was either already correct or a deliberate config/design choice:

| # | Item | Outcome |
|---|---|---|
| P1 | Zeal stack cap | Confirmed 3 (not 5) — doc corrected, code already right |
| P2 | Judgement vs. strike order | Confirmed both are GCD-consuming (stale code comment corrected); strike stays first — threat/buff upkeep outweighs occasional Judgement delay |
| P3 | HS/CS emphasis (talented Ret) | No change without a cast log (per audit) |
| P4 | Consecration as ST filler | Stays AoE-only — reserved for adds, poor damage/mana ratio solo |
| P5 | Holy Shield trigger | Tooltip confirms continuous-uptime design + self-sufficient value (block dmg + 50% threat); kept as recast-on-cooldown |
| P6 | Bulwark of the Righteous | Tooltip-corrected (5 min CD / 30% DR, not 3 min / 40%); deliberately left manual, not automated |
| P7 | Prot seal default | Kept SotC/SoR — SoW gated to level 18+, multi-paladin groups need to coordinate anyway |
| P8 | `sealTwist` default | Confirmed intentional — experimental/latency-sensitive |
| P9 | Heal-mode melee philosophy | Decided this session — single-target heals always precede Holy Strike |
| P10 | Daybreak tracking | Not worth it before tuning phase (per audit) |
| P11 | Pre-talent strike lean | Corrected "HS free" leveling claim — Zeal needs no talent, Holy Might doesn't exist without one; CS-lean confirmed correct |

## Test plan
- [ ] `python scripts/verify.py --all` — passes (confirmed before this PR).
- [ ] In-game: Paladin heal mode, position 25-35yd from a hurt group member below the Holy Shock emergency threshold — confirm Flash of Light/Holy Light now fires instead of nothing.
- [ ] In-game: Paladin/Priest/Druid/Shaman heal mode, hurt group member at 30-40yd — confirm they're now picked up as a heal candidate.
- [ ] Read through the P1-P11 reasoning in `docs/rotations.md` for anything that doesn't match your own Paladin experience — several of these were maintainer judgment calls (P4, P6, P7, P8) rather than hard mechanical facts.

Note: reviewer bandwidth for this PR is Paladin/Warlock/Rogue — the Priest/Druid/Shaman `Reachable()` changes are the same one-line-pattern fix mirrored across classes, not independently played-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)