### PR TITLE
v0.16.0: BuffUp integration, Rogue execute, Paladin double-heal fix

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -16,7 +16,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "0.15.3",
+    ver = "0.16.0",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,11 +2,12 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 0.15.3
+## Version: 0.16.0
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB
 
 Aegis_SBR.lua
 Aegis_SBR_UI.lua
+Aegis_SBR_BuffUp.lua
 Aegis_SBR_Minimap.lua
 classes\Class_Druid.lua
 classes\Class_Druid_UI.lua

--- a/Aegis_SBR_BuffUp.lua
+++ b/Aegis_SBR_BuffUp.lua
@@ -1,0 +1,944 @@
+-- ============================================================
+-- Aegis_SBR_BuffUp  -  buff / poison / weapon-enchant upkeep monitor
+-- Turtle WoW 1.12 frame API. No external libraries.
+-- ============================================================
+-- Ported and restyled from the standalone BuffUp addon (Zanthor), folded
+-- into Aegis so a single addon covers both the rotation and upkeep alerts.
+-- Two INDEPENDENT features, each with its own enable flag so one can run
+-- without the other (toggled in the minimap right-click panel):
+--   * Buff monitor  (all classes): watch chosen self-buffs and show clickable
+--                    rebuff buttons when any is missing. (Phase C.)
+--   * Poison control (rogue): weapon-poison presets + a Quick Bar to apply
+--                    them, plus rebuff prompts when a poison falls off. Config
+--                    lives in the Rogue class panel (consolidated with the
+--                    pre-pull poison reminder).
+-- Poison application needs a real click (hardware event), so it is always
+-- button-driven - never fired from the spammed rotation macro.
+-- ============================================================
+
+Aegis_SBR_BuffUp = {}
+local ABU = Aegis_SBR_BuffUp
+
+-- Flat-dark palette, mirrored from Aegis_SBR_UI's PAL (those are file-locals,
+-- not importable), so the Quick Bar and rebuff buttons match the config window.
+local PAL = {
+    bg    = {0.055, 0.059, 0.071, 0.97},
+    panel = {0.088, 0.096, 0.116, 1.0},
+    line  = {0.15,  0.165, 0.196, 1.0},
+    ink   = {0.91,  0.90,  0.88},
+    mute  = {0.55,  0.56,  0.60},
+}
+
+-- Class accent colours, mirrored from Aegis_SBR_UI (those are file-locals).
+-- The window always belongs to the player, so their own class token gives the
+-- right accent; falls back to gold.
+local CLASS_COLORS = {
+    WARRIOR = {0.78, 0.61, 0.43}, PALADIN = {0.96, 0.55, 0.73},
+    HUNTER  = {0.67, 0.83, 0.45}, ROGUE   = {1.00, 0.96, 0.41},
+    PRIEST  = {1.00, 1.00, 1.00}, SHAMAN  = {0.00, 0.44, 0.87},
+    MAGE    = {0.41, 0.80, 0.94}, WARLOCK = {0.58, 0.51, 0.79},
+    DRUID   = {1.00, 0.49, 0.04},
+}
+local function classColor()
+    local _, class = UnitClass("player")
+    return (class and CLASS_COLORS[class]) or {1, 0.82, 0}
+end
+
+-- Quick Bar sizing.
+local QB_BTN_W = 62
+local QB_BTN_H = 30
+local QB_BTN_GAP = 3
+local QB_HANDLE_W = 12
+local QB_MAX_PRESETS = 4
+local QB_BAR_H = 3       -- charge/time indicator bar height
+local QB_BAR_INSET = 4   -- inset of the bars from the button edge
+local QB_HALF_W = math.floor((62 - 2 * 4 - 2) / 2)  -- half-button bar width (QB_BTN_W/INSET), shared by create + render
+
+-- Stat capture: after applying a poison, read its full charges/duration once
+-- so the Quick Bar bars have a reference maximum to scale against.
+local CAPTURE_DELAY = 1.5    -- wait this long after apply before first read
+local CAPTURE_TIMEOUT = 6.0  -- give up after this many seconds
+
+-- Rebuff-button stack sizing.
+local BTN_W = 184
+local BTN_H = 30
+local BTN_START_Y = -210
+local BTN_SPACING = 34
+local BTN_MAX = 6
+
+-- Known poison duration tiers (ms), longest first - used later for the
+-- charge/time bars (Phase D). Kept here so SnapDuration is defined once.
+local KNOWN_DURATIONS = { 3600000, 1800000, 900000, 600000 }  -- 60m, 30m, 15m, 10m
+
+-- Runtime state (not saved).
+local abu_lastCheck = 0
+local abu_pendingRescan = nil
+local abu_lastPoisonMH = nil        -- preset index last applied to MH
+local abu_lastPoisonOH = nil        -- preset index last applied to OH
+local abu_pendingCaptureMH = nil    -- {readyAt, timeoutAt, itemName} after apply
+local abu_pendingCaptureOH = nil
+local abu_quickBar = nil
+local abu_qbButtons = {}
+local abu_buttonPool = {}
+
+-- ------------------------------------------------------------
+-- Saved state. Nested under AegisDB (per-character already). EnsureDB is
+-- idempotent and safe from any entry point before AegisDB.buffup exists.
+-- ------------------------------------------------------------
+function ABU:EnsureDB()
+    if type(AegisDB) ~= "table" then AegisDB = {} end
+    local db = AegisDB.buffup
+    if type(db) ~= "table" then db = {}; AegisDB.buffup = db end
+    if db.buffMonitor == nil then db.buffMonitor = false end
+    if db.poisonControl == nil then db.poisonControl = false end
+    if type(db.watchList) ~= "table" then db.watchList = {} end
+    if type(db.presets) ~= "table" then db.presets = {} end
+    if db.watchPoisonMH == nil then db.watchPoisonMH = false end
+    if db.watchPoisonOH == nil then db.watchPoisonOH = false end
+    if db.quickBarEnabled == nil then db.quickBarEnabled = true end
+    if db.quickBarPos == nil then db.quickBarPos = nil end
+    if type(db.poisonStats) ~= "table" then db.poisonStats = {} end
+    if db.checkInterval == nil then db.checkInterval = 1.0 end
+    -- Normalise presets to exactly QB_MAX_PRESETS slots.
+    for i = 1, QB_MAX_PRESETS do
+        if type(db.presets[i]) ~= "table" then db.presets[i] = { itemName = "", shortLabel = "" } end
+        if db.presets[i].itemName == nil then db.presets[i].itemName = "" end
+        if db.presets[i].shortLabel == nil then db.presets[i].shortLabel = "" end
+    end
+    return db
+end
+
+-- ------------------------------------------------------------
+-- Independent enable flags.
+-- ------------------------------------------------------------
+function ABU:BuffMonitorEnabled() return self:EnsureDB().buffMonitor == true end
+function ABU:PoisonControlEnabled() return self:EnsureDB().poisonControl == true end
+function ABU:SetBuffMonitor(on) self:EnsureDB().buffMonitor = (on == true); self:Refresh() end
+function ABU:SetPoisonControl(on) self:EnsureDB().poisonControl = (on == true); self:Refresh() end
+
+-- Poison-control sub-settings, edited from the Rogue class panel.
+function ABU:WatchPoisonMH() return self:EnsureDB().watchPoisonMH == true end
+function ABU:WatchPoisonOH() return self:EnsureDB().watchPoisonOH == true end
+function ABU:QuickBarEnabled() return self:EnsureDB().quickBarEnabled == true end
+function ABU:SetWatchPoisonMH(on) self:EnsureDB().watchPoisonMH = (on == true); self:Refresh() end
+function ABU:SetWatchPoisonOH(on) self:EnsureDB().watchPoisonOH = (on == true); self:Refresh() end
+function ABU:SetQuickBarEnabled(on) self:EnsureDB().quickBarEnabled = (on == true); self:Refresh() end
+
+-- Preset accessors for the Rogue config panel.
+function ABU:CountPresets()
+    local db = self:EnsureDB()
+    local n = 0
+    for i = 1, QB_MAX_PRESETS do
+        if db.presets[i].itemName ~= "" then n = n + 1 end
+    end
+    return n
+end
+
+function ABU:GetPreset(i)
+    local db = self:EnsureDB()
+    local p = db.presets[i]
+    return p.itemName, p.shortLabel
+end
+
+function ABU:SetPreset(i, itemName, shortLabel)
+    if i < 1 or i > QB_MAX_PRESETS then return end
+    local db = self:EnsureDB()
+    db.presets[i].itemName = itemName or ""
+    db.presets[i].shortLabel = shortLabel or ""
+    self:Refresh()
+end
+
+function ABU:MaxPresets() return QB_MAX_PRESETS end
+
+-- ------------------------------------------------------------
+-- Helpers.
+-- ------------------------------------------------------------
+local function Print(msg)
+    DEFAULT_CHAT_FRAME:AddMessage("|cff8fd3ffAegis|r: " .. tostring(msg))
+end
+
+local abu_scanTip = nil
+local function ScanTooltip()
+    if not abu_scanTip then
+        abu_scanTip = CreateFrame("GameTooltip", "Aegis_SBR_BuffUpScanTip", UIParent, "GameTooltipTemplate")
+    end
+    return abu_scanTip
+end
+
+-- Player can use weapon poisons (item-applied): rogues only. The poison
+-- control toggle is labelled "(rogue)" and does nothing for other classes.
+local function IsPoisonClass()
+    local _, class = UnitClass("player")
+    return class == "ROGUE"
+end
+
+-- Snap a captured remaining time to the nearest full tier; isFresh true when
+-- close to a full tier (used by the Phase-D charge/time bars).
+local function SnapDuration(capturedMs)
+    for i = 1, table.getn(KNOWN_DURATIONS) do
+        local dur = KNOWN_DURATIONS[i]
+        if capturedMs > dur * 0.85 then return dur, true end
+    end
+    return capturedMs, false
+end
+
+-- Short label for a preset button. An explicit shortLabel always wins;
+-- otherwise auto-abbreviate elegantly. Because the whole bar is poisons, the
+-- redundant word "Poison" is dropped and any rank kept, which reads far better
+-- than a hard mid-word cut: "Instant Poison VI" -> "Instant VI",
+-- "Dissolvent Poison" -> "Dissolvent". Only if it is STILL too long is it
+-- trimmed - keeping a trailing rank and never ending on a stray tilde.
+local PRESET_MAXLEN = 10
+local function PresetLabel(i)
+    local db = ABU:EnsureDB()
+    local p = db.presets[i]
+    if p.shortLabel and p.shortLabel ~= "" then return p.shortLabel end
+    local nm = p.itemName
+    if not nm or nm == "" then return "" end
+    local s = string.gsub(nm, "[Pp]oison", "")
+    s = string.gsub(s, "%s+", " ")   -- collapse doubled spaces left by the drop
+    s = string.gsub(s, "^%s+", "")
+    s = string.gsub(s, "%s+$", "")
+    if s == "" then s = nm end
+    if string.len(s) <= PRESET_MAXLEN then return s end
+    -- Still long: preserve a trailing rank (roman numerals or digits) and
+    -- shorten the leading part to fit, trimming any trailing space/punctuation
+    -- so it never ends on a stray "-" or space.
+    local _, _, rank = string.find(s, "%s+([IVXLCDM%d]+)$")
+    if rank then
+        local budget = PRESET_MAXLEN - string.len(rank) - 1
+        if budget < 1 then budget = 1 end
+        local head = string.gsub(string.sub(s, 1, budget), "[%s%p]+$", "")
+        return head .. " " .. rank
+    end
+    return string.gsub(string.sub(s, 1, PRESET_MAXLEN), "[%s%p]+$", "")
+end
+
+-- Find a poison item in the bags by (substring) name. Returns bag, slot.
+local function FindPoisonInBags(poisonName)
+    if not poisonName or poisonName == "" then return nil, nil end
+    for bag = 0, 4 do
+        local n = GetContainerNumSlots(bag) or 0
+        for slot = 1, n do
+            local link = GetContainerItemLink(bag, slot)
+            if link and string.find(link, poisonName, 1, true) then return bag, slot end
+        end
+    end
+    return nil, nil
+end
+
+-- Which preset (if any) is currently on a hand, by tooltip scan. invSlot 16=MH,
+-- 17=OH. Returns preset index or nil.
+local function DetectActivePoisonByTooltip(invSlot)
+    local db = ABU:EnsureDB()
+    if ABU:CountPresets() == 0 then return nil end
+    local tt = ScanTooltip()
+    tt:SetOwner(UIParent, "ANCHOR_NONE")
+    tt:ClearLines()
+    tt:SetInventoryItem("player", invSlot)
+    local numLines = tt:NumLines() or 0
+    for line = 1, numLines do
+        local region = getglobal("Aegis_SBR_BuffUpScanTipTextLeft" .. line)
+        local text = region and region:GetText()
+        if text and text ~= "" then
+            for i = 1, QB_MAX_PRESETS do
+                local nm = db.presets[i].itemName
+                if nm ~= "" and string.find(text, nm, 1, true) then
+                    tt:Hide()
+                    return i
+                end
+            end
+        end
+    end
+    tt:Hide()
+    return nil
+end
+
+-- Hybrid: tooltip scan first (survives /reload), runtime last-applied fallback.
+local function GetActivePoisonIndex(hand)
+    local hasMH, _, _, hasOH = GetWeaponEnchantInfo()
+    local invSlot, runtimeVar
+    if hand == "oh" then
+        if not hasOH then return nil end
+        invSlot = 17; runtimeVar = abu_lastPoisonOH
+    else
+        if not hasMH then return nil end
+        invSlot = 16; runtimeVar = abu_lastPoisonMH
+    end
+    local idx = DetectActivePoisonByTooltip(invSlot)
+    if idx then return idx end
+    return runtimeVar
+end
+
+-- Apply a preset poison to a hand. MUST be called from a button OnClick
+-- (hardware event) - the enchant-replace path is not valid from a script.
+function ABU:ApplyPoison(presetIdx, hand)
+    local db = self:EnsureDB()
+    local p = db.presets[presetIdx]
+    if not p or p.itemName == "" then
+        Print("|cffff6666Preset " .. presetIdx .. " not configured.|r")
+        return
+    end
+    local bag, slot = FindPoisonInBags(p.itemName)
+    if not bag then
+        Print("|cffff6666Not in bags:|r " .. p.itemName)
+        return
+    end
+    local invSlot = (hand == "oh") and 17 or 16
+    ClearCursor()
+    UseContainerItem(bag, slot)
+    PickupInventoryItem(invSlot)
+    ReplaceEnchant()
+    -- Schedule a one-off capture of this poison's full charges/duration if we
+    -- don't already have it, so the bars have a reference maximum.
+    if not db.poisonStats[p.itemName] then
+        local cap = { readyAt = GetTime() + CAPTURE_DELAY, timeoutAt = GetTime() + CAPTURE_TIMEOUT, itemName = p.itemName }
+        if hand == "oh" then abu_pendingCaptureOH = cap else abu_pendingCaptureMH = cap end
+    end
+    if hand == "oh" then abu_lastPoisonOH = presetIdx else abu_lastPoisonMH = presetIdx end
+    Print("|cff77dd77Poison:|r " .. p.itemName .. " -> " .. ((hand == "oh") and "Offhand" or "Mainhand"))
+end
+
+-- ============================================================
+-- Quick Bar (horizontal preset bar; rogue, poison control on)
+-- ============================================================
+local function CreateQuickBar()
+    if abu_quickBar then return abu_quickBar end
+    local f = CreateFrame("Frame", "Aegis_SBR_BuffUpQuickBar", UIParent)
+    f:SetWidth(QB_HANDLE_W + QB_BTN_W * QB_MAX_PRESETS + QB_BTN_GAP * (QB_MAX_PRESETS - 1) + 8)
+    f:SetHeight(QB_BTN_H + 8)
+    f:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 10,
+        insets = { left = 2, right = 2, top = 2, bottom = 2 },
+    })
+    f:SetBackdropColor(PAL.bg[1], PAL.bg[2], PAL.bg[3], PAL.bg[4])
+    f:SetBackdropBorderColor(PAL.line[1], PAL.line[2], PAL.line[3], 1)
+    f:SetFrameStrata("MEDIUM")
+    f:SetMovable(true)
+    f:EnableMouse(true)
+
+    local handle = CreateFrame("Button", nil, f)
+    handle:SetWidth(QB_HANDLE_W); handle:SetHeight(QB_BTN_H)
+    handle:SetPoint("LEFT", f, "LEFT", 3, 0)
+    handle:EnableMouse(true)
+    handle:RegisterForDrag("LeftButton", "RightButton")
+    handle:SetScript("OnDragStart", function() f:StartMoving() end)
+    handle:SetScript("OnDragStop", function()
+        f:StopMovingOrSizing()
+        local db = ABU:EnsureDB()
+        local point, _, relPoint, x, y = f:GetPoint()
+        db.quickBarPos = { point = point, relPoint = relPoint, x = x, y = y }
+    end)
+    local grip = handle:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    grip:SetPoint("CENTER", handle, "CENTER", 0, 0)
+    grip:SetText("|cff555555:::|r")
+
+    for i = 1, QB_MAX_PRESETS do
+        local b = CreateFrame("Button", "Aegis_SBR_BuffUpQB" .. i, f)
+        b:SetWidth(QB_BTN_W); b:SetHeight(QB_BTN_H)
+        if i == 1 then
+            b:SetPoint("LEFT", handle, "RIGHT", 3, 0)
+        else
+            b:SetPoint("LEFT", abu_qbButtons[i - 1], "RIGHT", QB_BTN_GAP, 0)
+        end
+        b:SetBackdrop({
+            bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+            edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+            tile = true, tileSize = 16, edgeSize = 8,
+            insets = { left = 2, right = 2, top = 2, bottom = 2 },
+        })
+        b:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+        local label = b:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        label:SetPoint("CENTER", b, "CENTER", 0, 0)
+        b.label = label
+        local mhInd = b:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        mhInd:SetPoint("LEFT", b, "LEFT", 3, 0)
+        b.mhInd = mhInd
+        local ohInd = b:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        ohInd:SetPoint("RIGHT", b, "RIGHT", -3, 0)
+        b.ohInd = ohInd
+
+        -- Charge (top) + time (bottom) bars, split left half = mainhand,
+        -- right half = offhand. Backgrounds are a dark track, the bars scale
+        -- against the poison's captured full charges/duration.
+        local function bar(anchor, ox, oy)
+            local bg = b:CreateTexture(nil, "ARTWORK")
+            bg:SetHeight(QB_BAR_H); bg:SetWidth(QB_HALF_W)
+            bg:SetPoint(anchor, b, anchor, ox, oy)
+            bg:SetTexture(0, 0, 0, 0.4)
+            local fill = b:CreateTexture(nil, "OVERLAY")
+            fill:SetHeight(QB_BAR_H); fill:SetWidth(QB_HALF_W)
+            fill:SetPoint(anchor, bg, anchor, 0, 0)
+            return bg, fill
+        end
+        b.mhChargesBg, b.mhChargesBar = bar("TOPLEFT",     QB_BAR_INSET,  -QB_BAR_INSET)
+        b.mhTimeBg,    b.mhTimeBar    = bar("BOTTOMLEFT",  QB_BAR_INSET,   QB_BAR_INSET)
+        b.ohChargesBg, b.ohChargesBar = bar("TOPRIGHT",   -QB_BAR_INSET,  -QB_BAR_INSET)
+        b.ohTimeBg,    b.ohTimeBar    = bar("BOTTOMRIGHT",-QB_BAR_INSET,   QB_BAR_INSET)
+        b.presetIdx = i
+        b:SetScript("OnClick", function()
+            -- Left = mainhand, right = offhand (mirror of BuffUp).
+            local hand = (arg1 == "RightButton") and "oh" or "mh"
+            ABU:ApplyPoison(this.presetIdx, hand)
+        end)
+        b:SetScript("OnEnter", function()
+            local nm = ABU:GetPreset(this.presetIdx)
+            if nm and nm ~= "" then
+                GameTooltip:SetOwner(this, "ANCHOR_TOP")
+                GameTooltip:SetText(nm)
+                -- Name is matched as a substring, so any rank in the bags
+                -- counts. Show which one would actually be applied.
+                local bag, slot = FindPoisonInBags(nm)
+                if bag then
+                    local link = GetContainerItemLink(bag, slot)
+                    GameTooltip:AddLine("In bags: " .. (link or "yes") .. " (any rank matches)", 0.5, 1, 0.5)
+                else
+                    GameTooltip:AddLine("Not in bags", 1, 0.4, 0.4)
+                end
+                GameTooltip:AddLine("Left-click: mainhand", 0.7, 1, 0.7)
+                GameTooltip:AddLine("Right-click: offhand", 0.7, 0.8, 1)
+                GameTooltip:Show()
+            end
+        end)
+        b:SetScript("OnLeave", function() GameTooltip:Hide() end)
+        abu_qbButtons[i] = b
+    end
+
+    -- Restore saved position, else default near the bottom centre.
+    local db = ABU:EnsureDB()
+    f:ClearAllPoints()
+    if db.quickBarPos then
+        f:SetPoint(db.quickBarPos.point or "CENTER", UIParent, db.quickBarPos.relPoint or "CENTER",
+            db.quickBarPos.x or 0, db.quickBarPos.y or 0)
+    else
+        f:SetPoint("BOTTOM", UIParent, "BOTTOM", 0, 180)
+    end
+    f:Hide()
+    abu_quickBar = f
+    return f
+end
+
+-- Render one hand's charge (top) + time (bottom) bar for a button, scaling
+-- against the poison's captured full charges / duration. Hidden when the hand
+-- is not carrying this preset or no stats have been captured yet.
+local function RenderBars(chargesBg, chargesBar, timeBg, timeBar, active, stats, curCharges, curExp)
+    if not (active and stats) then
+        chargesBg:Hide(); chargesBar:Hide(); timeBg:Hide(); timeBar:Hide()
+        return
+    end
+    local chargePct = 0
+    if stats.charges and stats.charges > 0 then chargePct = (curCharges or 0) / stats.charges end
+    if chargePct > 1 then chargePct = 1 end
+    local cW = QB_HALF_W * chargePct; if cW < 1 then cW = 1 end
+    chargesBar:SetWidth(cW)
+    if chargePct > 0.5 then chargesBar:SetTexture(0.2, 0.9, 0.2, 0.85)
+    elseif chargePct > 0.25 then chargesBar:SetTexture(0.9, 0.8, 0.1, 0.85)
+    else chargesBar:SetTexture(0.9, 0.2, 0.2, 0.85) end
+    local timePct = 0
+    if stats.timeMs and stats.timeMs > 0 then timePct = (curExp or 0) / stats.timeMs end
+    if timePct > 1 then timePct = 1 end
+    local tW = QB_HALF_W * timePct; if tW < 1 then tW = 1 end
+    timeBar:SetWidth(tW)
+    if timePct > 0.5 then timeBar:SetTexture(0.2, 0.6, 1, 0.85)
+    elseif timePct > 0.2 then timeBar:SetTexture(0.4, 0.4, 0.8, 0.85)
+    else timeBar:SetTexture(0.6, 0.2, 0.2, 0.85) end
+    chargesBg:Show(); chargesBar:Show(); timeBg:Show(); timeBar:Show()
+end
+
+local function UpdateQuickBar()
+    local db = ABU:EnsureDB()
+    local f = abu_quickBar or CreateQuickBar()
+    -- Only for rogues, with the feature on, the bar enabled, and presets set.
+    if not (db.poisonControl and db.quickBarEnabled and IsPoisonClass()) or ABU:CountPresets() == 0 then
+        f:Hide()
+        return
+    end
+
+    local mhIdx = GetActivePoisonIndex("mh")
+    local ohIdx = GetActivePoisonIndex("oh")
+    local hasMH, mhExp, mhCharges, hasOH, ohExp, ohCharges = GetWeaponEnchantInfo()
+
+    -- Pack only the configured presets, left to right, and size the frame to
+    -- exactly that many buttons (empty slots leave no gap).
+    local visible = 0
+    for i = 1, QB_MAX_PRESETS do
+        local b = abu_qbButtons[i]
+        local nm = db.presets[i].itemName
+        if nm ~= "" then
+            visible = visible + 1
+            b:ClearAllPoints()
+            b:SetPoint("LEFT", f, "LEFT", 4 + QB_HANDLE_W + (visible - 1) * (QB_BTN_W + QB_BTN_GAP), 0)
+            b.label:SetText(PresetLabel(i))
+            local isMH = (mhIdx == i)
+            local isOH = (ohIdx == i)
+            local available = (FindPoisonInBags(nm) ~= nil)
+            b.mhInd:SetText(isMH and "|cff77dd77M|r" or "")
+            b.ohInd:SetText(isOH and "|cff66aaffO|r" or "")
+            if isMH and isOH then
+                b:SetBackdropColor(0.10, 0.24, 0.13, 0.95); b:SetBackdropBorderColor(0.3, 0.9, 0.45, 0.9); b.label:SetTextColor(0.8, 1, 0.8)
+            elseif isMH then
+                b:SetBackdropColor(0.08, 0.20, 0.10, 0.95); b:SetBackdropBorderColor(0.3, 0.75, 0.35, 0.8); b.label:SetTextColor(0.75, 1, 0.75)
+            elseif isOH then
+                b:SetBackdropColor(0.06, 0.11, 0.24, 0.95); b:SetBackdropBorderColor(0.3, 0.5, 0.95, 0.8); b.label:SetTextColor(0.75, 0.85, 1)
+            elseif available then
+                b:SetBackdropColor(PAL.panel[1], PAL.panel[2], PAL.panel[3], 0.95); b:SetBackdropBorderColor(PAL.line[1], PAL.line[2], PAL.line[3], 1); b.label:SetTextColor(PAL.ink[1], PAL.ink[2], PAL.ink[3])
+            else
+                b:SetBackdropColor(0.10, 0.10, 0.10, 0.7); b:SetBackdropBorderColor(0.3, 0.3, 0.3, 0.5); b.label:SetTextColor(PAL.mute[1], PAL.mute[2], PAL.mute[3])
+            end
+            local stats = db.poisonStats[nm]
+            RenderBars(b.mhChargesBg, b.mhChargesBar, b.mhTimeBg, b.mhTimeBar, isMH, stats, mhCharges, mhExp)
+            RenderBars(b.ohChargesBg, b.ohChargesBar, b.ohTimeBg, b.ohTimeBar, isOH, stats, ohCharges, ohExp)
+            b:Show()
+        else
+            b:Hide()
+        end
+    end
+
+    f:SetWidth(QB_HANDLE_W + QB_BTN_W * visible + QB_BTN_GAP * (visible - 1) + 8)
+    f:Show()
+end
+
+-- ============================================================
+-- Buff monitor (all classes): detection + watch-list management
+-- ============================================================
+
+-- Highest spellbook slot matching a spell name (for casting a watched buff).
+local function FindSpellInBook(spellName)
+    if not spellName or spellName == "" then return nil end
+    local last = nil
+    local i = 1
+    while true do
+        local name = GetSpellName(i, BOOKTYPE_SPELL)
+        if not name then break end
+        if name == spellName then last = i end
+        i = i + 1
+        if i > 400 then break end
+    end
+    return last
+end
+
+-- Is a watched buff currently up? Matches the spell name via the buff tooltip
+-- first (rank/locale proof), then the icon texture as a fallback.
+local function PlayerHasBuff(texture, id, spellName)
+    local tt = ScanTooltip()
+    for i = 1, 32 do
+        local tex, _, bid = UnitBuff("player", i)
+        if not tex then break end
+        if id and bid and bid == id then return true end
+        if spellName and spellName ~= "" then
+            tt:SetOwner(UIParent, "ANCHOR_NONE")
+            tt:ClearLines()
+            tt:SetUnitBuff("player", i)
+            local region = getglobal("Aegis_SBR_BuffUpScanTipTextLeft1")
+            local name = region and region:GetText()
+            tt:Hide()
+            if name and name == spellName then return true end
+        elseif texture and tex and string.find(tex, texture) then
+            return true
+        end
+    end
+    return false
+end
+
+-- Snapshot the player's current buffs (texture, id, resolved spell name).
+local function ScanPlayerBuffs()
+    local out = {}
+    local tt = ScanTooltip()
+    for i = 1, 32 do
+        local tex, _, bid = UnitBuff("player", i)
+        if not tex then break end
+        tt:SetOwner(UIParent, "ANCHOR_NONE")
+        tt:ClearLines()
+        tt:SetUnitBuff("player", i)
+        local region = getglobal("Aegis_SBR_BuffUpScanTipTextLeft1")
+        local name = region and region:GetText()
+        tt:Hide()
+        table.insert(out, { texture = tex, id = bid, spellName = name or "" })
+    end
+    return out
+end
+
+-- Watch-list mutators (used by the config window).
+function ABU:AddWatch(entry)
+    local db = self:EnsureDB()
+    -- Skip duplicates by spell name (or texture when unnamed).
+    for i = 1, table.getn(db.watchList) do
+        local w = db.watchList[i]
+        if entry.spellName ~= "" and w.spellName == entry.spellName then return end
+        if entry.spellName == "" and w.texture == entry.texture then return end
+    end
+    table.insert(db.watchList, {
+        texture = entry.texture, id = entry.id,
+        spellName = entry.spellName or "",
+        label = (entry.spellName ~= "" and entry.spellName) or "Buff",
+    })
+    self:Refresh()
+end
+
+function ABU:RemoveWatch(index)
+    local db = self:EnsureDB()
+    table.remove(db.watchList, index)
+    self:Refresh()
+end
+
+function ABU:WatchList() return self:EnsureDB().watchList end
+function ABU:ScanBuffs() return ScanPlayerBuffs() end
+
+-- On SPELLS_CHANGED, refresh stored ids / names for watched buffs so a newly
+-- learned rank stays matched.
+function ABU:RescanBuffList()
+    local db = self:EnsureDB()
+    if table.getn(db.watchList) == 0 then return end
+    local cur = ScanPlayerBuffs()
+    for i = 1, table.getn(db.watchList) do
+        local w = db.watchList[i]
+        for j = 1, table.getn(cur) do
+            local c = cur[j]
+            if w.texture and c.texture and string.find(c.texture, w.texture) then
+                if c.spellName ~= "" and (not w.spellName or w.spellName == "") then
+                    w.spellName = c.spellName; w.label = c.spellName
+                end
+                if c.id and c.id ~= w.id then w.id = c.id end
+                break
+            end
+        end
+    end
+end
+
+-- ============================================================
+-- Rebuff-button stack (missing poison / missing watched buffs)
+-- ============================================================
+local function GetButton(index)
+    if abu_buttonPool[index] then return abu_buttonPool[index] end
+    local b = CreateFrame("Button", "Aegis_SBR_BuffUpBtn" .. index, UIParent)
+    b:SetWidth(BTN_W); b:SetHeight(BTN_H)
+    b:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 10,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    b:SetMovable(true); b:EnableMouse(true)
+    b:RegisterForDrag("RightButton")
+    b:SetScript("OnDragStart", function() this:StartMoving() end)
+    b:SetScript("OnDragStop", function() this:StopMovingOrSizing() end)
+    b:SetFrameStrata("DIALOG")
+    local txt = b:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    txt:SetPoint("CENTER", b, "CENTER", 0, 0)
+    b.text = txt
+    b:Hide()
+    abu_buttonPool[index] = b
+    return b
+end
+
+local function StyleButton(b, style)
+    if style == "poison" then
+        b:SetBackdropColor(0.13, 0.05, 0.18, 0.95); b:SetBackdropBorderColor(0.7, 0.4, 0.9, 0.9)
+    else
+        b:SetBackdropColor(0.05, 0.13, 0.18, 0.95); b:SetBackdropBorderColor(0.4, 0.75, 0.95, 0.9)
+    end
+end
+
+local function HideAllButtons()
+    for i = 1, BTN_MAX do
+        if abu_buttonPool[i] then abu_buttonPool[i]:Hide() end
+    end
+end
+
+-- Poison name to reapply for a rebuff prompt: the last one used on that hand,
+-- else the first configured preset.
+local function GetRebuffPoisonName(hand)
+    local db = ABU:EnsureDB()
+    local lastIdx = (hand == "oh") and abu_lastPoisonOH or abu_lastPoisonMH
+    if lastIdx and db.presets[lastIdx] and db.presets[lastIdx].itemName ~= "" then
+        return db.presets[lastIdx].itemName, lastIdx
+    end
+    for i = 1, QB_MAX_PRESETS do
+        if db.presets[i].itemName ~= "" then return db.presets[i].itemName, i end
+    end
+    return nil, nil
+end
+
+local function UpdateButtons()
+    local db = ABU:EnsureDB()
+    if UnitIsDeadOrGhost("player") then HideAllButtons(); return end
+
+    local missing = {}
+
+    -- Poison rebuff prompts (rogue, poison control on).
+    if db.poisonControl and IsPoisonClass() then
+        local hasMH, _, _, hasOH = GetWeaponEnchantInfo()
+        if db.watchPoisonMH and not hasMH then
+            local nm, idx = GetRebuffPoisonName("mh")
+            if nm and FindPoisonInBags(nm) then
+                table.insert(missing, { label = "|cffdd99ffPoison: Mainhand|r", style = "poison",
+                    action = function() ABU:ApplyPoison(idx, "mh") end })
+            end
+        end
+        if db.watchPoisonOH and not hasOH then
+            local nm, idx = GetRebuffPoisonName("oh")
+            if nm and FindPoisonInBags(nm) then
+                table.insert(missing, { label = "|cffdd99ffPoison: Offhand|r", style = "poison",
+                    action = function() ABU:ApplyPoison(idx, "oh") end })
+            end
+        end
+    end
+
+    -- Watched-buff rebuff prompts (all classes, buff monitor on).
+    if db.buffMonitor then
+        for i = 1, table.getn(db.watchList) do
+            local w = db.watchList[i]
+            if not PlayerHasBuff(w.texture, w.id, w.spellName) then
+                local sp = w.spellName
+                if sp and sp ~= "" then
+                    table.insert(missing, { label = "|cff88ddffBuff: " .. sp .. "|r", style = "buff",
+                        action = function()
+                            local id = FindSpellInBook(sp)
+                            if id then CastSpell(id, BOOKTYPE_SPELL) else CastSpellByName(sp) end
+                        end })
+                end
+            end
+        end
+    end
+
+    local count = table.getn(missing)
+    if count > BTN_MAX then count = BTN_MAX end
+    for i = 1, count do
+        local b = GetButton(i)
+        local data = missing[i]
+        b:ClearAllPoints()
+        b:SetPoint("TOP", UIParent, "TOP", 0, BTN_START_Y - (i - 1) * BTN_SPACING)
+        StyleButton(b, data.style)
+        b.text:SetText(data.label)
+        b.buffAction = data.action
+        b:SetScript("OnClick", function() if this.buffAction then this.buffAction() end end)
+        b:Show()
+    end
+    for i = count + 1, BTN_MAX do
+        if abu_buttonPool[i] then abu_buttonPool[i]:Hide() end
+    end
+end
+
+-- ============================================================
+-- Buff monitor config window (opened from the minimap panel)
+-- ============================================================
+local CFG_ROW_H = 18
+local CFG_WATCH_MAX = 8
+local CFG_SCAN_MAX = 12
+
+local function cfgRow(parent, y)
+    local r = CreateFrame("Button", nil, parent)
+    r:SetPoint("TOPLEFT", parent, "TOPLEFT", 12, y)
+    r:SetPoint("TOPRIGHT", parent, "TOPRIGHT", -12, y)
+    r:SetHeight(CFG_ROW_H)
+    local hl = r:CreateTexture(nil, "BACKGROUND")
+    hl:SetAllPoints(r); hl:SetTexture(1, 1, 1, 0.06); hl:Hide()
+    local t = r:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    t:SetPoint("LEFT", r, "LEFT", 4, 0); t:SetJustifyH("LEFT")
+    r.text = t
+    r:SetScript("OnEnter", function() hl:Show() end)
+    r:SetScript("OnLeave", function() hl:Hide() end)
+    r:Hide()
+    return r
+end
+
+function ABU:CreateConfigWindow()
+    if self.cfgWin then return self.cfgWin end
+    local w = CreateFrame("Frame", "Aegis_SBR_BuffUpConfig", UIParent)
+    w:SetWidth(300)
+    w:SetHeight(30 + 20 + CFG_WATCH_MAX * CFG_ROW_H + 28 + CFG_SCAN_MAX * CFG_ROW_H + 16)
+    w:SetPoint("CENTER", UIParent, "CENTER", 0, 40)
+    w:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 12,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    local cc = classColor()
+    w:SetBackdropColor(PAL.bg[1], PAL.bg[2], PAL.bg[3], 0.98)
+    w:SetBackdropBorderColor(cc[1], cc[2], cc[3], 1)   -- class-coloured frame
+    w:SetFrameStrata("DIALOG")
+    w:EnableMouse(true); w:SetMovable(true)
+    w:RegisterForDrag("LeftButton")
+    w:SetScript("OnDragStart", function() w:StartMoving() end)
+    w:SetScript("OnDragStop", function() w:StopMovingOrSizing() end)
+    w:Hide()
+
+    -- Class-tinted title bar strip across the top, plus a hairline under it.
+    local titleBar = w:CreateTexture(nil, "ARTWORK")
+    titleBar:SetPoint("TOPLEFT", w, "TOPLEFT", 4, -4)
+    titleBar:SetPoint("TOPRIGHT", w, "TOPRIGHT", -4, -4)
+    titleBar:SetHeight(22)
+    titleBar:SetTexture(cc[1], cc[2], cc[3], 0.14)
+    local accent = w:CreateTexture(nil, "OVERLAY")
+    accent:SetPoint("TOPLEFT", w, "TOPLEFT", 4, -26)
+    accent:SetPoint("TOPRIGHT", w, "TOPRIGHT", -4, -26)
+    accent:SetHeight(1)
+    accent:SetTexture(cc[1], cc[2], cc[3], 0.8)
+
+    local title = w:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    title:SetPoint("TOPLEFT", 12, -9)
+    title:SetText("Buff monitor")
+    title:SetTextColor(cc[1], cc[2], cc[3])
+
+    local close = CreateFrame("Button", nil, w, "UIPanelCloseButton")
+    close:SetPoint("TOPRIGHT", 2, 2)
+    close:SetScript("OnClick", function() w:Hide() end)
+
+    local watchLbl = w:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    watchLbl:SetPoint("TOPLEFT", 12, -30)
+    watchLbl:SetText("|cffaaccffWatched buffs|r (click to remove)")
+
+    w.watchRows = {}
+    local y = -48
+    for i = 1, CFG_WATCH_MAX do
+        w.watchRows[i] = cfgRow(w, y)
+        y = y - CFG_ROW_H
+    end
+
+    local scanLbl = w:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    scanLbl:SetPoint("TOPLEFT", 12, y - 6)
+    scanLbl:SetText("|cffaaccffYour current buffs|r (click to watch)")
+
+    local rescan = CreateFrame("Button", nil, w, "UIPanelButtonTemplate")
+    rescan:SetWidth(64); rescan:SetHeight(18)
+    rescan:SetPoint("TOPRIGHT", -12, y - 4)
+    rescan:SetText("Rescan")
+    rescan:SetScript("OnClick", function() ABU:RefreshConfigWindow() end)
+
+    w.scanRows = {}
+    y = y - 24
+    for i = 1, CFG_SCAN_MAX do
+        w.scanRows[i] = cfgRow(w, y)
+        y = y - CFG_ROW_H
+    end
+
+    self.cfgWin = w
+    return w
+end
+
+function ABU:RefreshConfigWindow()
+    local w = self.cfgWin
+    if not w then return end
+    local db = self:EnsureDB()
+
+    -- Watched list (click to remove).
+    for i = 1, CFG_WATCH_MAX do
+        local row = w.watchRows[i]
+        local entry = db.watchList[i]
+        if entry then
+            row.text:SetText("|cffff8888x|r  " .. (entry.label or entry.spellName or "Buff"))
+            row.idx = i
+            row:SetScript("OnClick", function() ABU:RemoveWatch(this.idx); ABU:RefreshConfigWindow() end)
+            row:Show()
+        else
+            row:Hide()
+        end
+    end
+
+    -- Current buffs (click to add), skipping ones already watched.
+    local cur = ScanPlayerBuffs()
+    local shown = 0
+    for i = 1, table.getn(cur) do
+        local c = cur[i]
+        local already = false
+        for j = 1, table.getn(db.watchList) do
+            local wtc = db.watchList[j]
+            if (c.spellName ~= "" and wtc.spellName == c.spellName)
+                or (c.spellName == "" and wtc.texture == c.texture) then already = true; break end
+        end
+        if not already and shown < CFG_SCAN_MAX then
+            shown = shown + 1
+            local row = w.scanRows[shown]
+            row.text:SetText("|cff88ff88+|r  " .. ((c.spellName ~= "" and c.spellName) or "(unnamed icon)"))
+            row.entry = c
+            row:SetScript("OnClick", function() ABU:AddWatch(this.entry); ABU:RefreshConfigWindow() end)
+            row:Show()
+        end
+    end
+    for i = shown + 1, CFG_SCAN_MAX do w.scanRows[i]:Hide() end
+end
+
+function ABU:ToggleConfigWindow()
+    local w = self:CreateConfigWindow()
+    if w:IsShown() then w:Hide(); return end
+    self:RefreshConfigWindow()
+    w:Show(); w:Raise()
+end
+
+-- ------------------------------------------------------------
+-- Refresh: dispatch to the feature renderers, gated per flag.
+-- ------------------------------------------------------------
+function ABU:Refresh()
+    local db = self:EnsureDB()
+    if db.poisonControl then
+        UpdateQuickBar()
+    elseif abu_quickBar then
+        abu_quickBar:Hide()
+    end
+    UpdateButtons()
+end
+
+-- ------------------------------------------------------------
+-- Driver: one throttled OnUpdate that fans out to the renderers.
+-- ------------------------------------------------------------
+local abu_frame = CreateFrame("Frame", "Aegis_SBR_BuffUpFrame")
+abu_frame:RegisterEvent("VARIABLES_LOADED")
+abu_frame:RegisterEvent("SPELLS_CHANGED")
+
+abu_frame:SetScript("OnUpdate", function()
+    local db = ABU:EnsureDB()
+    if not (db.buffMonitor or db.poisonControl) then
+        if abu_quickBar and abu_quickBar:IsShown() then abu_quickBar:Hide() end
+        return
+    end
+    local now = GetTime()
+    local interval = db.checkInterval or 1.0
+    if now - abu_lastCheck < interval then return end
+    abu_lastCheck = now
+    if abu_pendingRescan and now >= abu_pendingRescan then
+        abu_pendingRescan = nil
+        ABU:RescanBuffList()
+    end
+
+    -- Capture a freshly applied poison's full charges/duration (retry until
+    -- the enchant reads close to a full tier, or give up after the timeout).
+    local hasMH, mhExp, mhCharges, hasOH, ohExp, ohCharges = GetWeaponEnchantInfo()
+    if abu_pendingCaptureMH and now >= abu_pendingCaptureMH.readyAt then
+        if now > abu_pendingCaptureMH.timeoutAt then
+            abu_pendingCaptureMH = nil
+        elseif hasMH and mhCharges and mhCharges > 0 and mhExp and mhExp > 0 then
+            local snapped, isFresh = SnapDuration(mhExp)
+            if isFresh then
+                db.poisonStats[abu_pendingCaptureMH.itemName] = { charges = mhCharges, timeMs = snapped }
+                abu_pendingCaptureMH = nil
+            end
+        end
+    end
+    if abu_pendingCaptureOH and now >= abu_pendingCaptureOH.readyAt then
+        if now > abu_pendingCaptureOH.timeoutAt then
+            abu_pendingCaptureOH = nil
+        elseif hasOH and ohCharges and ohCharges > 0 and ohExp and ohExp > 0 then
+            local snapped, isFresh = SnapDuration(ohExp)
+            if isFresh then
+                db.poisonStats[abu_pendingCaptureOH.itemName] = { charges = ohCharges, timeMs = snapped }
+                abu_pendingCaptureOH = nil
+            end
+        end
+    end
+
+    ABU:Refresh()
+end)
+
+abu_frame:SetScript("OnEvent", function()
+    if event == "VARIABLES_LOADED" then
+        ABU:EnsureDB()
+        return
+    end
+    if event == "SPELLS_CHANGED" then
+        if not abu_pendingRescan then abu_pendingRescan = GetTime() + 3 end
+        return
+    end
+end)

--- a/Aegis_SBR_Minimap.lua
+++ b/Aegis_SBR_Minimap.lua
@@ -178,7 +178,7 @@ end
 -- ============================================================
 local function buildPanel()
     local p = CreateFrame("Frame", "Aegis_SBR_MinimapPanel", UIParent)
-    p:SetWidth(232); p:SetHeight(214)
+    p:SetWidth(232); p:SetHeight(276)
     p:SetFrameStrata("DIALOG")
     p:SetBackdrop({
         bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
@@ -281,6 +281,40 @@ local function buildPanel()
     hint:SetJustifyH("LEFT")
     hint:SetText("Assist mirrors that player's target by GUID, not by name - a same-named mob from another group is never mistaken for theirs.")
 
+    -- Upkeep monitors: two INDEPENDENT toggles (Aegis_SBR_BuffUp). Buff monitor
+    -- watches self-buffs and shows rebuff buttons; poison control drives the
+    -- rogue poison Quick Bar. Each writes only its own flag, so one can run
+    -- without the other.
+    local monLabel = p:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    monLabel:SetPoint("TOPLEFT", 12, -156)
+    monLabel:SetText("Upkeep monitors")
+
+    local function makeCheck(yOff, text, onClick)
+        local c = CreateFrame("CheckButton", nil, p, "UICheckButtonTemplate")
+        c:SetWidth(16); c:SetHeight(16)
+        c:SetPoint("TOPLEFT", 14, yOff)
+        local lbl = p:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        lbl:SetPoint("LEFT", c, "RIGHT", 4, 0)
+        lbl:SetText(text)
+        c:SetScript("OnClick", function() onClick(this:GetChecked() and true or false) end)
+        return c
+    end
+
+    p.buffMonCheck = makeCheck(-176, "Buff monitor", function(on)
+        if Aegis_SBR_BuffUp then Aegis_SBR_BuffUp:SetBuffMonitor(on) end
+    end)
+    -- Opens the buff monitor's own config window (watch list + buff scan).
+    local buffCfgBtn = CreateFrame("Button", nil, p, "UIPanelButtonTemplate")
+    buffCfgBtn:SetWidth(74); buffCfgBtn:SetHeight(18)
+    buffCfgBtn:SetPoint("TOPRIGHT", p, "TOPRIGHT", -12, -175)
+    buffCfgBtn:SetText("Configure")
+    buffCfgBtn:SetScript("OnClick", function()
+        if Aegis_SBR_BuffUp then Aegis_SBR_BuffUp:ToggleConfigWindow() end
+    end)
+    p.poisonCheck = makeCheck(-196, "Poison control (rogue)", function(on)
+        if Aegis_SBR_BuffUp then Aegis_SBR_BuffUp:SetPoisonControl(on) end
+    end)
+
     local cfg = CreateFrame("Button", nil, p, "UIPanelButtonTemplate")
     cfg:SetWidth(208); cfg:SetHeight(22)
     cfg:SetPoint("BOTTOM", 0, 12)
@@ -302,6 +336,10 @@ function AM:RefreshPanel()
     p.manualRadio:SetChecked(mode == "manual")
     p.assistRadio:SetChecked(mode == "assist")
     p.assistEdit:SetText((AegisDB and AegisDB.assistTarget) or "")
+    if p.buffMonCheck and Aegis_SBR_BuffUp then
+        p.buffMonCheck:SetChecked(Aegis_SBR_BuffUp:BuffMonitorEnabled())
+        p.poisonCheck:SetChecked(Aegis_SBR_BuffUp:PoisonControlEnabled())
+    end
 end
 
 function AM:TogglePanel()

--- a/Aegis_SBR_UI.lua
+++ b/Aegis_SBR_UI.lua
@@ -832,6 +832,37 @@ function Aegis_SBR_Layout:Row(o)
     return item
 end
 
+-- A full-width clickable row: a left label plus an optional right-aligned
+-- value column (e.g. the current setting), the whole row acting as a button.
+-- Used for free-text settings that open a dialog on click (poison presets).
+-- Returns the button; caller reads btn.label / btn.value to update text.
+function Aegis_SBR_Layout:Button(o)
+    self:_sep()
+    local hl = self:_hl(LAY.VROW_H)
+    local P = self.host or self.p
+    local btn = CreateFrame("Button", nil, P)
+    btn:SetPoint("TOPLEFT", P, "TOPLEFT", 10, self.y - 4)
+    btn:SetPoint("TOPRIGHT", P, "TOPRIGHT", -10, self.y - 4)
+    btn:SetHeight(LAY.VROW_H - 6)
+    local lab = FS(btn, "GameFontNormalSmall", o.label or "")
+    SetFontSafe(lab, false, 12)
+    lab:SetPoint("LEFT", btn, "LEFT", 2, 0)
+    lab:SetTextColor(PAL.ink[1], PAL.ink[2], PAL.ink[3])
+    lab:SetJustifyH("LEFT")
+    local val = FS(btn, "GameFontNormalSmall", "")
+    SetFontSafe(val, false, 11)
+    val:SetPoint("RIGHT", btn, "RIGHT", -2, 0)
+    val:SetWidth(150); val:SetJustifyH("RIGHT")
+    val:SetTextColor(PAL.mute[1], PAL.mute[2], PAL.mute[3])
+    btn.label = lab
+    btn.value = val
+    if o.onClick then btn:SetScript("OnClick", o.onClick) end
+    wireHover(btn, hl)
+    self:_rec(btn, true); self:_rec(lab, false); self:_rec(val, false)
+    self.y = self.y - LAY.VROW_H
+    return btn
+end
+
 -- Close the last section and stack everything; returns the content height.
 function Aegis_SBR_Layout:Finish()
     self:_closeSection()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v0.16.0 — BuffUp integration (buff monitor + rogue poison Quick Bar), Rogue execute, Paladin double-heal fix
+
+**Feature + fixes.** Folds the standalone **BuffUp** addon into Aegis as an optional upkeep monitor, adds a rogue execute finisher, and fixes a Paladin double-heal. If you ran standalone BuffUp, you can now retire it — Aegis covers the same ground.
+
+### ✨ BuffUp integration (new `Aegis_SBR_BuffUp.lua`)
+Two **independent** features, each toggled in the minimap right-click panel (new "Upkeep monitors" section), so one can run without the other:
+- **Buff monitor** (all classes): watch chosen self-buffs; when one is missing, a clickable rebuff button appears on screen to recast it. Its own config window (class-coloured frame) opens from the minimap panel's **Configure** button — scan your current buffs and click to watch, click a watched entry to remove. Buff detection is name-based (rank/locale proof) with an icon-texture fallback; a `SPELLS_CHANGED` rescan keeps a newly-learned rank matched.
+- **Poison control** (rogue): a movable **Quick Bar** of up to 4 poison presets — left-click a preset for mainhand, right-click for offhand — plus optional rebuff buttons when a poison falls off. Presets are configured in the **Rogue class panel** (Poisons section): enter just the poison *type* (e.g. "Instant Poison", **no rank**) and whatever rank is in your bags is found and applied automatically. Each Quick Bar button shows charge and remaining-time bars (mainhand left, offhand right), captured on first apply. Applying a poison needs a real click, so it is always button-driven, never cast from the rotation macro. The bar auto-sizes to the number of configured presets, and preset labels abbreviate elegantly (drop the redundant "Poison", keep the rank).
+- Poison presets / buff watch list are stored per character (`AegisDB.buffup`), shared across profiles.
+- New shared UI primitive `Aegis_SBR_Layout:Button` (a clickable label+value row) backs the preset editors.
+- **Not ported from standalone BuffUp:** OG-Twink interop (dropped). Shaman weapon imbues are already covered by the class panel's Weapon-imbue upkeep (auto-cast, superior to a manual button), so they were intentionally left there.
+
+### ✨ Added
+- **Rogue — Execute low-HP targets** (opt-in, default OFF; Finishers section). Below a configurable health threshold (default 10%), Eviscerate fires with whatever combo points are on hand instead of waiting for the normal threshold, so points aren't wasted on a kill. Ruthlessness guarantees at least one combo point after any finisher, so this is rarely blocked. Adds an `exec=` field to `/sbr trace`.
+
+### 🔧 Changed
+- **Rogue — pre-pull poison reminder retired.** The chat warning is superseded by the poison Quick Bar / rebuff buttons, which surface a missing poison on screen. (Poisons *can* be applied in combat via those buttons; the old reminder's "pre-pull only" assumption is gone.)
+
+### 🐛 Fixed
+- **Paladin — double heal on a topped-off target.** Two causes: (1) `StillCasting` now reads the client's real cast bar (`CastingBarFrame`) instead of a cast-time estimate, so a spammed press during a Holy Light cast (2.5s, longer than the 1.5s GCD) can't start a second heal before the first lands — this also correctly accounts for Nampower's queue starting the cast slightly later than the call. (2) The in-flight-heal prediction no longer discards itself when an actively-tanked target dips below its commit-time health during the post-cast latency window; the prediction is additive and capped, so it self-corrects for real new damage without re-healing a target the first heal already covered.
+
+---
+
 ## v0.15.3 — Warrior shout upkeep: Battle Shout + Demoralizing Shout (audit W1 + W4)
 
 **Feature (rotation, user-approved).** Implements the two shout gaps the Phase 1 audit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation ⚔️ (v0.15.3)
+# Aegis: Single Button Rotation ⚔️ (v0.16.0)
 
 **Smart, Modular Combat Automation for Turtle WoW (1.18.1)**
 

--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -609,15 +609,13 @@ end
 -- ============================================================
 
 -- Record an in-flight heal so the next press does not pile onto the same unit.
--- Also stamps their real HP at commit time (see PendingFor) and our own
--- expected cast completion (see StillCasting) - Holy Light's 2.5s cast is
--- longer than the 1.5s global cooldown, so GcdReady() alone reports "ready"
--- up to a full second before the cast actually finishes.
+-- Also stamps our own expected cast completion (see StillCasting) - Holy
+-- Light's 2.5s cast is longer than the 1.5s global cooldown, so GcdReady()
+-- alone reports "ready" up to a full second before the cast actually finishes.
 function M:CommitHeal(unit, amount, castTime)
     self.healTarget = UnitName(unit)
     self.healAmount = amount or 0
     self.healUntil = GetTime() + (castTime or 0) + 1.0
-    self.healBaseline = UnitHealth(unit)
     self.castingUntil = GetTime() + (castTime or 0)
 end
 
@@ -626,21 +624,39 @@ end
 -- whose cast time exceeds the GCD (Holy Light at 2.5s), where a spammed
 -- press could otherwise start a second heal before the first has landed,
 -- since the target's HP (and PendingFor's prediction) hasn't updated yet.
+-- Checks the client's OWN cast-bar state first (CastingBarFrame.casting),
+-- which reflects the real, server-confirmed cast regardless of exactly when
+-- Nampower's queue actually started it - Nampower queues a press that lands
+-- during an active cast/GCD and fires it the instant that cast completes, a
+-- behavior that applies to plain CastSpellByName too, not just calls that
+-- explicitly use QueueSpellByName (see docs/dependencies.md). A castTime-based
+-- guess (castingUntil) assumes the cast started the instant CastSpellByName
+-- was called, which is not guaranteed once Nampower's queue is involved -
+-- the real cast bar sidesteps that assumption entirely. castingUntil stays
+-- as a fallback for the rare case CastingBarFrame is unavailable.
 function M:StillCasting()
+    if CastingBarFrame and (CastingBarFrame.casting or CastingBarFrame.channeling) then
+        return true
+    end
     return self.castingUntil and GetTime() < self.castingUntil
 end
 
--- Predicted incoming heal for a unit from our own pending cast, else 0. Only
--- trusted while their REAL health hasn't dropped below what it was at commit
--- time - otherwise new damage landed after the heal was queued, and letting
--- the stale prediction pad WorstHurt's health estimate back up would mask a
--- fresh crisis for the rest of the cast (up to ~castTime + 1s) instead of
--- reacting to it immediately.
+-- Predicted incoming heal for a unit from our own pending cast, else 0. The
+-- caller (WorstHurt) ADDS this to the unit's real current HP and clamps to
+-- max, so the prediction can never over-claim: it self-corrects for new
+-- damage. A tank that keeps taking hits while the heal is in flight simply
+-- has a lower real HP, and real + pending lands wherever it actually will;
+-- only a hit big enough that even the incoming heal won't cover it leaves the
+-- unit below the threshold and eligible for another heal. This is why there
+-- is no "discard if HP dropped below commit-time baseline" guard here - that
+-- guard re-healed any actively-tanked target during the post-cast latency
+-- window (real HP already below commit time, but the landed heal's HP update
+-- not yet arrived from the server), causing the exact overheal it was meant
+-- to avoid. The window is bounded by healUntil (castTime + 1s of latency
+-- slack) so a resisted/failed cast self-corrects quickly.
 function M:PendingFor(unit)
     if self.healTarget and GetTime() < self.healUntil and UnitName(unit) == self.healTarget then
-        if UnitHealth(unit) >= (self.healBaseline or 0) then
-            return self.healAmount
-        end
+        return self.healAmount
     end
     return 0
 end

--- a/classes/Class_Rogue.lua
+++ b/classes/Class_Rogue.lua
@@ -43,16 +43,19 @@ M.templates = {
     starter = {  -- valid for any rogue, only Slice and Dice upkeep
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
         useSurpriseAttack = false,
+        useExecute = false, executeHpPct = 10,
         cpFinish = 4, popCDs = false, autoCDElite = false,
     },
     assassination = {
         builder = "", useSnd = true, useEnvenom = true, useRupture = true, useRiposte = true,
         useSurpriseAttack = false,
+        useExecute = false, executeHpPct = 10,
         cpFinish = 4, popCDs = false, autoCDElite = false,
     },
     combat = {
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
         useSurpriseAttack = true,
+        useExecute = false, executeHpPct = 10,
         cpFinish = 5, popCDs = false, autoCDElite = true,
     },
 }
@@ -74,14 +77,17 @@ function M:NormalizeProfile(c)
     if c.useRupture == nil then c.useRupture = false end
     if c.useRiposte == nil then c.useRiposte = false end
     if c.useSurpriseAttack == nil then c.useSurpriseAttack = false end
+    -- Execute: finish with whatever combo points are on hand once the target
+    -- is nearly dead, instead of risking them going to waste on a kill.
+    -- Ruthlessness (Assassination talent, 100% at 3/3) guarantees at least 1
+    -- combo point after any finisher, so there is always something to spend.
+    if c.useExecute == nil then c.useExecute = false end
+    if c.executeHpPct == nil then c.executeHpPct = 10 end
     if c.cpFinish == nil then c.cpFinish = 4 end
     if c.popCDs == nil then c.popCDs = false end
     if c.autoCDElite == nil then c.autoCDElite = false end
-    -- Poison reminder: warn (only) when a weapon poison is missing on entering
-    -- combat. Poisons can't be applied in combat, so this is a pre-pull nudge,
-    -- never an auto-apply. Default OFF. See docs/research-weapon-enchant-upkeep.md.
-    if c.poisonReminder == nil then c.poisonReminder = false end
     -- old keys from any earlier format are dropped silently
+    c.poisonReminder = nil   -- retired: superseded by the Aegis_SBR_BuffUp poison Quick Bar / rebuff buttons
     return c
 end
 
@@ -150,6 +156,13 @@ function M:Rotate(cfg)
     local cp = GetComboPoints("player", "target")
     local now = GetTime()
 
+    -- Execute: below a low HP threshold, finish with whatever combo points
+    -- are on hand rather than risk them going to waste if the target dies
+    -- before reaching the normal cpFinish. Requires at least 1 combo point
+    -- (Ruthlessness, 100% at 3/3, guarantees one is on hand after any
+    -- finisher, so this is rarely blocked once a fight is underway).
+    local execute = cfg.useExecute and cp >= 1 and self:TargetHPPct() <= (cfg.executeHpPct or 10)
+
     if self.trace then
         self:Trace("cp=" .. cp
             .. " build=" .. builder
@@ -158,6 +171,7 @@ function M:Rotate(cfg)
             .. " rup=" .. (useRup and (self:TargetDebuffUp("Rupture", "Ability_Rogue_Rupture") and "up" or "down") or "-")
             .. " rip=" .. ((cfg.useRiposte and now < (self.riposteExpiry or 0)) and "Y" or "N")
             .. " sa=" .. ((cfg.useSurpriseAttack and now < (self.surpriseExpiry or 0)) and "Y" or "N")
+            .. " exec=" .. (cfg.useExecute and (execute and "Y" or "N") or "-")
             .. " elite=" .. (isElite and "Y" or "N"),
             -- Rogue never downranks (all ranks cost the same energy), so every
             -- Cast() below is a bare CastSpellByName(name) - vanilla resolves
@@ -237,8 +251,8 @@ function M:Rotate(cfg)
         if self:Cast("Rupture") then return end
     end
 
-    -- P6 buffs healthy, enough combo points, Eviscerate
-    if cp >= cpEvis then
+    -- P6 buffs healthy, enough combo points (or target about to die), Eviscerate
+    if cp >= cpEvis or execute then
         self:Cast("Eviscerate")
         return
     end
@@ -266,43 +280,18 @@ function M:HandleCommand(cmd, t)
 end
 
 -- ============================================================
--- Poison reminder (warn only). Poisons are item-applied and cannot be put on
--- in combat, so the honest feature is a pre-pull nudge: on entering combat,
--- if the active profile opts in and a weapon poison is missing, print a
--- warning. Detection via the core WeaponEnchant helper (GetWeaponEnchantInfo);
--- the off-hand is only nagged about when an off-hand weapon is actually
--- equipped. No auto-apply. See docs/research-weapon-enchant-upkeep.md.
--- ============================================================
-function M:PoisonCheck()
-    local cfg = Aegis_SBR:GetActiveProfile()
-    if not cfg or not cfg.poisonReminder then return end
-    if not GetWeaponEnchantInfo then return end   -- no detection API: degrade
-    local missing = {}
-    if not Aegis_SBR:WeaponEnchant("main") then table.insert(missing, "main-hand") end
-    if not Aegis_SBR:WeaponEnchant("off")
-        and GetInventoryItemLink and GetInventoryItemLink("player", 17) then
-        table.insert(missing, "off-hand")
-    end
-    if table.getn(missing) > 0 then
-        Aegis_SBR:Msg("poison missing on your " .. table.concat(missing, " and ")
-            .. " - apply before pulling.", 1, 0.5, 0.3)
-    end
-end
-
--- ============================================================
--- Parry window tracker for Riposte + the poison reminder on combat enter.
--- Owned by the module, stays inert while both options are off.
+-- Parry window tracker for Riposte. Owned by the module, stays inert while
+-- Riposte is not learned or the option is off. (The old pre-pull poison
+-- reminder was retired: the poison Quick Bar / rebuff buttons in
+-- Aegis_SBR_BuffUp already surface a missing poison on screen.)
 -- ============================================================
 local riposteFrame = CreateFrame("Frame")
 riposteFrame:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
-riposteFrame:RegisterEvent("PLAYER_REGEN_DISABLED")   -- entered combat (the pull)
 riposteFrame:SetScript("OnEvent", function()
     if event == "CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES" then
         if arg1 and string.find(string.lower(arg1), "parry") then
             M.riposteExpiry = GetTime() + 5.5
         end
-    elseif event == "PLAYER_REGEN_DISABLED" then
-        M:PoisonCheck()
     end
 end)
 

--- a/classes/Class_Rogue_UI.lua
+++ b/classes/Class_Rogue_UI.lua
@@ -28,13 +28,40 @@ function M:BuildBody(ui, parent)
     self.saRow = L:Row{ key = "useSurpriseAttack", label = "Surprise Attack", spell = "Surprise Attack", onToggle = set("useSurpriseAttack") }
     self.cpRow = L:Row{ label = "Eviscerate at CP",
         slider = { key = "cpFinish", min = 1, max = 5, step = 1, suffix = "", onChange = set("cpFinish") } }
+    self.execRow = L:Row{ key = "useExecute", label = "Execute low-HP targets", onToggle = set("useExecute"),
+        slider = { key = "executeHpPct", min = 1, max = 30, step = 1, suffix = "%", onChange = set("executeHpPct") } }
 
     L:Header("Cooldowns")
     self.cdRow = L:Row{ key = "popCDs", label = "Pop cooldowns", onToggle = set("popCDs") }
     self.cdEliteRow = L:Row{ key = "autoCDElite", label = "Auto on elite", onToggle = set("autoCDElite") }
 
+    -- Poisons: the poison-control settings (Quick Bar + rebuff) live in the
+    -- shared Aegis_SBR_BuffUp module (global per character, not per profile), so
+    -- their toggles write there directly. The pre-pull reminder stays a
+    -- per-profile setting. Presets open a text dialog on click.
     L:Header("Poisons")
-    self.poisonRow = L:Row{ key = "poisonReminder", label = "Poison reminder", onToggle = set("poisonReminder") }
+    local function abu(fn) return function(v) if Aegis_SBR_BuffUp then Aegis_SBR_BuffUp[fn](Aegis_SBR_BuffUp, v) end end end
+    self.pcRow  = L:Row{ key = "abuPoisonControl", label = "Poison control (Quick Bar + rebuff)", onToggle = abu("SetPoisonControl") }
+    self.pmhRow = L:Row{ key = "abuWatchMH", label = "Rebuff button: mainhand", onToggle = abu("SetWatchPoisonMH") }
+    self.pohRow = L:Row{ key = "abuWatchOH", label = "Rebuff button: offhand", onToggle = abu("SetWatchPoisonOH") }
+    self.qbRow  = L:Row{ key = "abuQuickBar", label = "Show poison Quick Bar", onToggle = abu("SetQuickBarEnabled") }
+    self.presetBtns = {}
+    local maxp = (Aegis_SBR_BuffUp and Aegis_SBR_BuffUp:MaxPresets()) or 4
+    for i = 1, maxp do
+        local idx = i
+        self.presetBtns[idx] = L:Button{ label = "Preset " .. idx, onClick = function()
+            local cur = ""
+            if Aegis_SBR_BuffUp then cur = (Aegis_SBR_BuffUp:GetPreset(idx)) or "" end
+            Aegis_SBR_UI:ShowDialog({
+                prompt = "Poison type for preset " .. idx .. " (name only, no rank - e.g. Instant Poison)",
+                withInput = true, initialText = cur, acceptLabel = "Save",
+                onAccept = function(txt)
+                    if Aegis_SBR_BuffUp then Aegis_SBR_BuffUp:SetPreset(idx, txt or "", "") end
+                    ui:Refresh()
+                end,
+            })
+        end }
+    end
 
     L:Finish()
 
@@ -45,9 +72,17 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.ripRow.cb, "Riposte", "Cast right after a parry, inside the short Riposte window.")
     ui:Tip(self.saRow.cb, "Surprise Attack", "Cast right after the TARGET dodges you, inside a short window (mirror image of Riposte).", "Combat capstone (20 points). Guaranteed hit, cheap, awards a combo point.")
     ui:Tip(self.cpRow.slider, "Finisher combo points", "Eviscerate is used once combo points reach this number.")
+    ui:Tip(self.execRow.cb, "Execute low-HP targets", "Below the health value on the right, Eviscerate fires with whatever combo points are on hand (at least 1) instead of waiting for the normal threshold.", "Ruthlessness guarantees a combo point after any finisher, so this rarely goes unused once a fight is underway.")
+    ui:Tip(self.execRow.slider, "Execute below", "Target health percent under which Eviscerate finishes early rather than risk combo points going to waste on a kill.")
     ui:Tip(self.cdRow.cb, "Pop cooldowns", "Use Adrenaline Rush and Blade Flurry every press (off the global cooldown).")
     ui:Tip(self.cdEliteRow.cb, "Auto on elite", "Pop the cooldowns only against elite and boss targets.")
-    ui:Tip(self.poisonRow.cb, "Poison reminder", "Warn when a weapon poison is missing as you enter combat. Poisons can't be applied in combat, so this is a pre-pull reminder only - it never auto-applies.")
+    ui:Tip(self.pcRow.cb, "Poison control", "Master switch for the poison Quick Bar and rebuff buttons (also in the minimap right-click menu). Applies to this character across all rogue profiles.", "Applying a poison needs a real click, so it is always button-driven, never cast from the rotation macro.")
+    ui:Tip(self.pmhRow.cb, "Rebuff button: mainhand", "Show a click-to-apply button when the mainhand poison has fallen off.")
+    ui:Tip(self.pohRow.cb, "Rebuff button: offhand", "Show a click-to-apply button when the offhand poison has fallen off.")
+    ui:Tip(self.qbRow.cb, "Show poison Quick Bar", "A small movable bar of your poison presets: left-click a preset for mainhand, right-click for offhand.")
+    for i = 1, table.getn(self.presetBtns) do
+        ui:Tip(self.presetBtns[i], "Poison preset " .. i, "Click to set the poison type for this preset - just the name, NO rank (e.g. Instant Poison, not Instant Poison VI).", "Whatever rank of that poison is in your bags is found and applied automatically, so you never have to update the preset when you learn a higher rank.")
+    end
 end
 
 -- ============================================================
@@ -72,11 +107,28 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.saRow, buf.useSurpriseAttack)
     ui:BindCheck(self.cdRow, buf.popCDs)
     ui:BindCheck(self.cdEliteRow, buf.autoCDElite)
-    ui:BindCheck(self.poisonRow, buf.poisonReminder)
 
     local cpv = buf.cpFinish or 4
     self.cpRow.slider:SetValue(cpv)
     if self.cpRow.slider.valText then self.cpRow.slider.valText:SetText(tostring(cpv)) end
+
+    ui:BindCheck(self.execRow, buf.useExecute)
+    local execv = buf.executeHpPct or 10
+    self.execRow.slider:SetValue(execv)
+    if self.execRow.slider.valText then self.execRow.slider.valText:SetText(execv .. "%") end
+
+    -- Poison-control rows bind to the global Aegis_SBR_BuffUp state, not the
+    -- profile buffer, so they are set directly here.
+    if Aegis_SBR_BuffUp then
+        self.pcRow.cb:SetChecked(Aegis_SBR_BuffUp:PoisonControlEnabled())
+        self.pmhRow.cb:SetChecked(Aegis_SBR_BuffUp:WatchPoisonMH())
+        self.pohRow.cb:SetChecked(Aegis_SBR_BuffUp:WatchPoisonOH())
+        self.qbRow.cb:SetChecked(Aegis_SBR_BuffUp:QuickBarEnabled())
+        for i = 1, table.getn(self.presetBtns) do
+            local nm = Aegis_SBR_BuffUp:GetPreset(i)
+            self.presetBtns[i].value:SetText((nm and nm ~= "") and nm or "|cff666666(empty)|r")
+        end
+    end
 end
 
 -- Open the shared window for this class.


### PR DESCRIPTION
## Summary
Three pieces, all tested in-game this session. Full detail in the CHANGELOG entry.

### BuffUp integration (new `Aegis_SBR_BuffUp.lua`)
The standalone BuffUp addon (buff/poison/enchant monitor) folded into Aegis as an optional upkeep monitor. Two **independent** features, each toggled in the minimap right-click panel's new "Upkeep monitors" section:
- **Buff monitor** (all classes): watch chosen self-buffs; a clickable rebuff button appears when one is missing. Own class-coloured config window (scan current buffs → click to watch; click a watched entry to remove), opened from the minimap panel's **Configure** button.
- **Poison control** (rogue): movable Quick Bar of up to 4 poison presets (left-click mainhand, right-click offhand), charge/time bars per button, optional rebuff buttons. Presets configured in the **Rogue class panel** — enter the poison *type* only (no rank; any rank in bags is matched). Applying a poison needs a real click, so it is always button-driven, never from the rotation macro.
- State per character in `AegisDB.buffup`. New shared `Aegis_SBR_Layout:Button` UI primitive. OG-Twink interop intentionally dropped; shaman weapon imbues stay on the existing class-panel auto-upkeep (superior to a manual button).

### Rogue — Execute low-HP targets (opt-in, default OFF)
Below a configurable threshold (default 10%), Eviscerate fires with whatever combo points are on hand rather than waiting for `cpFinish`, so points aren't wasted on a kill. Ruthlessness guarantees ≥1 combo point after any finisher. Adds `exec=` to `/sbr trace`.

### Paladin — double-heal fix
On a topped-off target, a second heal could fire right as the first landed. Two causes fixed: (1) `StillCasting` now reads the real `CastingBarFrame` instead of a cast-time estimate (also covers Nampower queueing the cast slightly after the call); (2) the in-flight heal prediction no longer discards itself when an actively-tanked target dips below its commit-time HP during the post-cast latency window — the prediction is additive and capped, self-correcting for real new damage.

Also retires the rogue pre-pull poison reminder (superseded by the Quick Bar / rebuff buttons).

## Notes
- Rebased onto current `main` (v0.15.3 + your Warrior shout work); version cut to **v0.16.0**, all version spots synced, `scripts/verify.py --all` green.
- Reviewer bandwidth here is Paladin/Warlock/Rogue — the buff-monitor is class-agnostic but was exercised on those.
- Once merged, standalone BuffUp can be retired.

## Test plan
- [ ] `python scripts/verify.py --all` (green pre-push).
- [ ] Minimap right-click → toggle Buff monitor / Poison control independently; both persist across `/reload`.
- [ ] Rogue: configure a poison preset (name only), enable Poison control → Quick Bar appears, click applies, charge/time bars fill, bar auto-sizes to preset count.
- [ ] Buff monitor: Configure → watch a current buff → let it drop → clickable rebuff button appears and recasts.
- [ ] Rogue execute: enable, tag a target below 10% with <cpFinish points → Eviscerate fires early.
- [ ] Paladin heal mode: spam through a Holy Light cast on a topped-off tank → no second heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)