### PR TITLE
Warlock: DoT order, execute-phase DoT stop, Dark Harvest over Life Tap

### DIFF
--- a/classes/Class_Warlock.lua
+++ b/classes/Class_Warlock.lua
@@ -3,8 +3,12 @@
 -- Turtle WoW 1.12 (SuperWoW). DoT priority, configurable, level 1+.
 -- ============================================================
 -- Model (mirrors the proven leveling macro):
---  * Keep the enabled damage-over-time effects up in priority order,
---    Immolate, then the chosen Curse, then Corruption, then Siphon Life.
+--  * Keep the enabled damage-over-time effects up in priority order:
+--    Immolate, the chosen Curse, Siphon Life, the Malediction Curse of
+--    Agony, then Corruption (see the order block in Rotate for why).
+--  * Below an optional target-health threshold no DoT is re-applied at all
+--    (a fresh DoT never pays its mana back on a mob about to die), with an
+--    opt-in exception for Corruption, the cheapest and shortest of them.
 --  * Malediction (optional): if the main curse is not Curse of Agony or
 --    Curse of Doom, that talent piggybacks Curse of Agony on every curse
 --    cast. Enabling coaSecondary tracks and refreshes that DoT on its own.
@@ -63,6 +67,15 @@ local DH_CHANNEL_BASE = 8
 -- enabled DoT with less than that is topped up first (see DotRemaining, which
 -- also backs this boost out of its estimate for a channel that already ran).
 local DH_TICK_BOOST = 0.30
+
+-- Dark Harvest's mana cost, read off the in-game tooltip (Rank 1/1, 230 mana -
+-- it has a single rank, so there is no per-rank table to keep). Used only to
+-- decide whether a ready channel is actually affordable before letting it take
+-- priority over Life Tap (see the Life Tap block in Rotate). Deliberately
+-- compared as a hard floor: understating it would let the rotation queue a
+-- channel that fails in-game while the cooldown never starts, which stalls the
+-- next press on the same dead attempt. Adjust here if Turtle changes the cost.
+local DH_MANA = 230
 
 -- Once an enabled DoT is due to fall off within this many seconds, the wand
 -- filler stops (or does not start) feeding new shots. Reacting only after the
@@ -196,17 +209,26 @@ M.templates = {
         healthFunnel = true, healthFunnelPetHp = 50, healthFunnelHpMin = 45,
         useShadowburn = false, shadowburnHp = 20,
         useDrainSoul = true, drainSoulHp = 20,
+        dotStopHp = 20, dotStopKeepCorruption = true,
     },
     affliction = {
+        -- Dark Harvest is the Affliction capstone and the strongest filler by a
+        -- wide margin (it also accelerates the shadow DoTs already ticking), so
+        -- it leads here. Until it is talented, ResolveFiller drops to the wand -
+        -- deliberately not Shadow Bolt, which is far too mana-hungry to spam as
+        -- a filler; it stays reserved for the free Shadow Trance procs.
         useImmolate = false, curse = "Curse of Agony", useCorruption = true, useSiphonLife = true,
-        filler = "Shadow Bolt", petAttack = true,
+        filler = "Dark Harvest", petAttack = true,
         lifeTap = true, lifeTapMana = 25, lifeTapHpMin = 40,
         drainLifeSustain = true, drainLifeHp = 35,
         healthFunnel = true, healthFunnelPetHp = 50, healthFunnelHpMin = 45,
         useShadowburn = false, shadowburnHp = 20,
         useDrainSoul = false, drainSoulHp = 20,
+        dotStopHp = 20, dotStopKeepCorruption = true,
     },
     destruction = {
+        -- Shadow Bolt stays the filler here: Destruction never reaches Dark
+        -- Harvest, and its whole kit is built around Shadow Bolt spam.
         useImmolate = true, curse = "Curse of the Elements", useCorruption = false, useSiphonLife = false,
         filler = "Shadow Bolt", petAttack = true,
         lifeTap = true, lifeTapMana = 25, lifeTapHpMin = 40,
@@ -214,6 +236,7 @@ M.templates = {
         healthFunnel = true, healthFunnelPetHp = 50, healthFunnelHpMin = 45,
         useShadowburn = true, shadowburnHp = 20,
         useDrainSoul = false, drainSoulHp = 20,
+        dotStopHp = 20, dotStopKeepCorruption = true,
     },
 }
 
@@ -253,6 +276,11 @@ function M:NormalizeProfile(c)
     if c.coaSecondary == nil then c.coaSecondary = false end
     if c.keepShards == nil then c.keepShards = false end
     if c.shardTarget == nil then c.shardTarget = 3 end
+    -- Execute-phase DoT stop. Defaults to 0 (off) rather than the templates'
+    -- 20, so a profile saved before this existed keeps its old behaviour until
+    -- the slider is moved; fresh profiles get the efficiency straight away.
+    if c.dotStopHp == nil then c.dotStopHp = 0 end
+    if c.dotStopKeepCorruption == nil then c.dotStopKeepCorruption = true end
     return c
 end
 
@@ -296,17 +324,17 @@ end
 
 -- Resolve the configured filler to one that can actually fire right now.
 -- The wand filler needs a wand equipped; a spell filler needs to be learned.
--- When neither holds, fall back to Shadow Bolt (the warlock's level 1 nuke and
--- universal filler) so the rotation always has something to cast while
--- leveling. Returns nil only if even Shadow Bolt is somehow unknown.
+-- When the chosen one cannot fire, fall back to the WAND first and only then to
+-- Shadow Bolt: spamming Shadow Bolt as a filler burns far more mana than it is
+-- worth (it is kept for the free Shadow Trance procs instead), while the wand
+-- costs nothing. This matters most for an Affliction profile set to Dark
+-- Harvest before the capstone is talented - that used to silently fall through
+-- to Shadow Bolt spam. Shadow Bolt remains the last resort so a warlock with no
+-- wand equipped still has something to cast; nil only if even that is unknown.
 function M:ResolveFiller(cfg)
     local f = cfg.filler or "Shoot"
-    if f == "Shoot" then
-        if self:HasWand() then return "Shoot" end
-        if self:KnowsSpell("Shadow Bolt") then return "Shadow Bolt" end
-        return nil
-    end
-    if self:KnowsSpell(f) then return f end
+    if f ~= "Shoot" and self:KnowsSpell(f) then return f end
+    if self:HasWand() then return "Shoot" end
     if self:KnowsSpell("Shadow Bolt") then return "Shadow Bolt" end
     return nil
 end
@@ -667,7 +695,23 @@ function M:Rotate(cfg)
         end
     end
 
-    -- Build the ordered DoT list from the enabled, known effects.
+    -- Build the ordered DoT list from the enabled, known effects. The order is
+    -- deliberate, and anything switched off simply lets the rest move up:
+    --  1. Immolate, while it is still in use. Its cast time is the point at low
+    --     levels: those extra ~1.5s let the pet build aggro before your own
+    --     damage lands. It is normally switched off around 30, where its
+    --     damage-per-mana falls behind the shadow DoTs and the cast time turns
+    --     from an asset into a cost.
+    --  2. The chosen curse. Curse of Agony's damage is back-loaded, so it needs
+    --     the head start; Curse of the Elements/Shadow amplify damage taken and
+    --     are applied per tick (not snapshot at cast), so landing them before
+    --     the DoTs means every later tick is already buffed.
+    --  3. Siphon Life. It only pays its mana back if it runs most of its 30s,
+    --     so a late application is a straight loss - it has to go on early.
+    --  4. The Malediction Curse of Agony, back-loaded like the main curse and
+    --     therefore ahead of flat-damage Corruption.
+    --  5. Corruption. Instant and the best damage-per-mana of the set, so it
+    --     loses the least by being applied last.
     local order = {}
     if cfg.useImmolate then table.insert(order, { "Immolate", self.dotTex["Immolate"], 3 }) end
     if cfg.curse ~= "" then
@@ -678,6 +722,7 @@ function M:Rotate(cfg)
         local detectable = tex or Aegis_SBR:CanResolveDebuffNames()
         table.insert(order, { cfg.curse, tex, detectable and 3 or 20 })
     end
+    if cfg.useSiphonLife then table.insert(order, { "Siphon Life", self.dotTex["Siphon Life"], 3 }) end
     -- Malediction secondary curse: with that talent Curse of Agony coexists
     -- with the main curse, but expires sooner and is otherwise unmonitored.
     -- When enabled, keep it up on its own. Skipped if the main curse already
@@ -690,7 +735,18 @@ function M:Rotate(cfg)
         table.insert(order, { "Curse of Agony", coaTex, coaDetectable and 3 or 20 })
     end
     if cfg.useCorruption then table.insert(order, { "Corruption", self.dotTex["Corruption"], 3 }) end
-    if cfg.useSiphonLife then table.insert(order, { "Siphon Life", self.dotTex["Siphon Life"], 3 }) end
+
+    -- Execute phase: stop RE-APPLYING DoTs once the target is nearly dead. A
+    -- fresh DoT never pays its mana back on a mob with seconds to live - Siphon
+    -- Life needs most of its 30s to break even and Curse of Agony's damage is
+    -- back-loaded, so both are pure waste there. Corruption can be exempted
+    -- (dotStopKeepCorruption): it is the shortest and cheapest of them, which
+    -- is exactly why the drain-tank guides keep refreshing that one alone.
+    -- Only re-application stops; DoTs already ticking are never touched, and
+    -- the press falls through to the filler (or Shadowburn / Drain Soul, which
+    -- have already had their own shot above).
+    local dotStopHp = cfg.dotStopHp or 0
+    local dotsSuppressed = dotStopHp > 0 and thp <= dotStopHp
 
     if self.trace then
         local up = ""
@@ -698,12 +754,15 @@ function M:Rotate(cfg)
             local sp, tex = order[i][1], order[i][2]
             up = up .. " " .. sp .. "=" .. (tex and (self:TargetHasTexture(tex) and "Y" or "n") or "?")
         end
-        self:Trace("dots" .. up .. " mana=" .. string.format("%.0f", self:ManaPct()))
+        self:Trace("dots" .. up .. " mana=" .. string.format("%.0f", self:ManaPct())
+            .. " dotstop=" .. (dotStopHp > 0 and (dotsSuppressed and "Y" or "n") or "-"))
     end
 
     for i = 1, table.getn(order) do
         local sp, tex, iv = order[i][1], order[i][2], order[i][3]
-        if self:KnowsSpell(sp) then
+        local exempt = cfg.dotStopKeepCorruption and sp == "Corruption"
+        local allowed = (not dotsSuppressed) or exempt
+        if self:KnowsSpell(sp) and allowed then
             local st = self:ApplyDot(sp, tex, iv)
             if st == "cast" or st == "wait" then return end
             -- "up": continue to the next DoT
@@ -711,7 +770,21 @@ function M:Rotate(cfg)
     end
 
     -- All enabled DoTs up. Optional Life Tap, then the filler.
-    if cfg.lifeTap and self:KnowsSpell("Life Tap") then
+    --
+    -- A Dark Harvest that is ready AND affordable goes first, though. The DoT
+    -- top-up in the branch below exists precisely so the channel gets its full
+    -- boosted duration; spending a GCD on Life Tap here eats into that same
+    -- headroom, so by the time the channel would start a DoT has dropped under
+    -- the threshold again and gets re-applied - a second GCD and the mana Life
+    -- Tap had just bought, both wasted. Tapping one press later costs nothing:
+    -- the channel itself is ~7.5s during which no GCD is spent anyway.
+    -- The affordability check matters - without it a channel we cannot pay for
+    -- would be queued, fail in-game, and (its cooldown never having started)
+    -- be retried on the very next press, stalling the rotation instead of
+    -- fixing the mana. Below the cost, Life Tap keeps its turn.
+    local dhFirst = cfg.filler == "Dark Harvest" and self:KnowsSpell("Dark Harvest")
+        and self:OwnCDReady("Dark Harvest") and (UnitMana("player") or 0) >= DH_MANA
+    if cfg.lifeTap and self:KnowsSpell("Life Tap") and not dhFirst then
         if self:ManaPct() < (cfg.lifeTapMana or 20) and self:PlayerHPPct() > (cfg.lifeTapHpMin or 40) then
             self:Queue("Life Tap")
             return
@@ -746,13 +819,19 @@ function M:Rotate(cfg)
                     end
                 end
             end
-            for i = 1, table.getn(order) do
-                local sp = order[i][1]
-                if self:KnowsSpell(sp) then
-                    local remain = self:DotRemaining(sp)
-                    if remain and remain < minRemain then
-                        self:QueueDot(sp, self:TargetId())
-                        return
+            -- Skipped entirely in the execute phase: topping a DoT up there is
+            -- the same wasted mana the stop above avoids, and the sooner the
+            -- channel starts on a dying target the better - a target that dies
+            -- mid-channel resets Dark Harvest's cooldown outright.
+            if not dotsSuppressed then
+                for i = 1, table.getn(order) do
+                    local sp = order[i][1]
+                    if self:KnowsSpell(sp) then
+                        local remain = self:DotRemaining(sp)
+                        if remain and remain < minRemain then
+                            self:QueueDot(sp, self:TargetId())
+                            return
+                        end
                     end
                 end
             end

--- a/classes/Class_Warlock_UI.lua
+++ b/classes/Class_Warlock_UI.lua
@@ -45,6 +45,10 @@ function M:BuildBody(ui, parent)
         slider = { key = "dsHp", min = 0, max = 100, step = 5, suffix = "%", onChange = set("drainSoulHp") } }
     self.shardRow = L:Row{ key = "keepShards", label = "Stop early to keep shards", onToggle = set("keepShards"),
         slider = { key = "shardTarget", min = 1, max = 60, step = 1, suffix = "", onChange = set("shardTarget") } }
+    self.dotStopRow = L:Row{ label = "Stop new DoTs below",
+        slider = { key = "dotStopHp", min = 0, max = 50, step = 5, suffix = "%", onChange = set("dotStopHp") } }
+    self.dotStopCorrRow = L:Row{ key = "dotStopKeepCorruption", label = "Keep Corruption up anyway", spell = "Corruption",
+        onToggle = set("dotStopKeepCorruption") }
 
     L:Header("Survival")
     self.drainRow = L:Row{ key = "drainLifeSustain", label = "Drain Life when low", spell = "Drain Life", onToggle = set("drainLifeSustain"),
@@ -75,6 +79,8 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.dsoulRow.slider, "Drain below", "Target health percent under which Drain Soul channels.")
     ui:Tip(self.shardRow.cb, "Stop early to keep shards", "Once you hold at least this many shards, Drain Soul stops finishing targets so the filler (or Shadowburn) takes over instead.")
     ui:Tip(self.shardRow.slider, "Shard target", "Drain Soul keeps finishing targets while you hold fewer shards than this.")
+    ui:Tip(self.dotStopRow.slider, "Stop new DoTs below", "Below this target health, no damage-over-time effect is applied or refreshed any more - the press goes to your filler instead.", "A fresh DoT never earns its mana back on a mob about to die: Siphon Life needs most of its 30s to break even and Curse of Agony's damage comes at the end. Set to 0 to switch this off. DoTs already ticking are never cancelled.")
+    ui:Tip(self.dotStopCorrRow.cb, "Keep Corruption up anyway", "Exempt Corruption from the stop above, so it alone is still refreshed while the target is nearly dead.", "Corruption is the shortest and most mana-efficient of the DoTs, which is why it is the one worth refreshing when nothing else is.")
     ui:Tip(self.drainRow.cb, "Drain Life when low", "Self-heal channel when your health dips below the value - the drain-tank safety net.")
     ui:Tip(self.funnelRow.cb, "Health Funnel pet", "Top the pet up when it drops, as long as your own health is safe (it transfers yours to the pet).")
     ui:Tip(self.drainRow.slider, "Heal below", "Your health percent under which Drain Life is channeled.")
@@ -155,6 +161,17 @@ function M:RefreshBody(ui, buf)
         ui:Color(self.shardRow.label, ui.COL.grey)
     end
     ui:SliderEnable(self.shardRow.slider, dsoulOn and buf.keepShards)
+
+    -- DoT stop: the slider is always live (0 switches the feature off), and the
+    -- Corruption exception only means anything while the stop is actually armed.
+    self.dotStopRow.slider:SetValue(buf.dotStopHp or 0)
+    self.dotStopRow.slider.valText:SetText((buf.dotStopHp or 0) .. "%")
+    ui:SliderEnable(self.dotStopRow.slider, true)
+    ui:BindCheck(self.dotStopCorrRow, buf.dotStopKeepCorruption)
+    if (buf.dotStopHp or 0) <= 0 then
+        self.dotStopCorrRow.cb:Disable()
+        ui:Color(self.dotStopCorrRow.label, ui.COL.grey)
+    end
 
     -- Survival
     ui:BindCheck(self.drainRow, buf.drainLifeSustain)


### PR DESCRIPTION
Warlock efficiency pass, derived from *Dive's Drain Tanking Guide* plus in-game verification. The guide is Classic-2019, so its Classic-only advice was discarded where Turtle 1.18.1 differs — Turtle has no **Dark Pact** and no **Amplify Curse**; **Dark Harvest** is the Affliction capstone instead. Tested in-game before opening this.

## DoT order

Now **Immolate → curse → Siphon Life → Malediction Curse of Agony → Corruption**.

Net change is Siphon Life moving up from last place: it only pays its mana back if it runs most of its 30s, so a late application is a straight loss. Immolate deliberately stays first while it is enabled — its cast time is the *point* at low levels, buying the pet time to build aggro before our own damage lands. Once it is switched off (usually around 30, where its damage-per-mana falls behind the shadow DoTs), everything moves up on its own.

## Execute-phase DoT stop (new)

A slider plus a toggle that exempts Corruption. Below the target-health threshold no DoT is applied or refreshed — a fresh DoT never earns its mana back on a mob about to die. Corruption is exempt by default, being the shortest and cheapest of them.

Only *re-application* stops; DoTs already ticking are untouched.

Dark Harvest's pre-channel DoT top-up honours the same stop. That top-up would otherwise undercut the whole point, and starting the channel sooner on a dying target is better anyway — per the tooltip, a target that dies mid-channel resets Dark Harvest's cooldown outright.

Defaults to `0` (off) in `NormalizeProfile` so **saved profiles keep their current behaviour**, and to `20` in the templates so fresh profiles get the efficiency straight away.

## Dark Harvest now outranks Life Tap

Life Tap yields to a Dark Harvest that is ready **and** affordable.

Reported from play: the pre-channel top-up exists so the channel gets its full boosted duration, but spending a GCD on Life Tap first ate into exactly that headroom — a DoT then fell back under the threshold and got re-applied, costing a second GCD *plus* the mana Life Tap had just bought.

The affordability check is load-bearing, not decoration: an unaffordable channel would be queued, fail in-game, and — its cooldown never having started — be retried on the very next press, stalling the rotation instead of fixing the mana. Below the cost, Life Tap keeps its turn.

## Filler fixes

- The `affliction` template now leads with **Dark Harvest** instead of Shadow Bolt.
- `ResolveFiller` falls back to the **wand** before Shadow Bolt.

Spamming Shadow Bolt as a filler is far too mana-hungry; it stays reserved for the free Shadow Trance procs, which was already implemented. Previously an Affliction profile set to Dark Harvest *before* the capstone was talented fell silently into Shadow Bolt spam. Destruction keeps Shadow Bolt — it never reaches Dark Harvest.

## Notes

- Adds a `dotstop=` field to `/sbr trace`.
- `scripts/verify.py --all` green.
- No version bump, per the existing pattern of feature commits followed by a separate `Cut vX.Y.Z`.
- Still open: whether Dark Harvest accelerates **Curse of Doom**'s single 60s tick. Not testable yet (not learned); would need an entry in `dotNumTicks` if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)