### PR TITLE
Rogue tuning (buff-renew window, Cold Blood) + a press log for measuring it

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -149,7 +149,67 @@ end
 -- Throttled per-press trace, toggled with /sbr trace. Accepts any number of
 -- lines; the throttle is checked once so multi-line traces are never half
 -- swallowed (Lua 5.0 packs varargs into the implicit `arg` table).
+-- ============================================================
+-- Press log (AegisLog). The 1.12 Lua sandbox has no file access at all - no
+-- io, no os - so the only way to get data off the client is a SavedVariable,
+-- which the client serialises to
+--   WTF\Account\<ACCOUNT>\<Realm>\<Char>\SavedVariables\Aegis_SBR.lua
+-- on /reload or logout. It is therefore NOT live: nothing is on disk until
+-- one of those happens. Kept in its own SavedVariable rather than inside
+-- AegisDB so a big log can never bloat or endanger the profile data, and so
+-- it can be cleared on its own.
+--
+-- A true ring buffer (write index that wraps) rather than append-and-trim:
+-- table.remove(t, 1) would shift every entry on every press, which at a
+-- multi-thousand cap is real work inside the rotation's hot path.
+-- ============================================================
+local LOG_MAX = 2000
+
+function Aegis_SBR:LogInit(reset)
+    if type(AegisLog) ~= "table" then AegisLog = {} end
+    if reset or type(AegisLog.entries) ~= "table" then
+        AegisLog.entries = {}
+        AegisLog.pos = 0        -- entries written since the last clear (can exceed max)
+        AegisLog.max = LOG_MAX
+        AegisLog.started = date and date("%Y-%m-%d %H:%M:%S") or ""
+        AegisLog.t0 = GetTime()
+    end
+    if not AegisLog.t0 then AegisLog.t0 = GetTime() end
+    if not AegisLog.max then AegisLog.max = LOG_MAX end
+    return AegisLog
+end
+
+-- Append one line. Timestamps are seconds since the log was (re)started, so
+-- the file stays readable without needing wall-clock per entry.
+function Aegis_SBR:LogWrite(text)
+    if not text then return end
+    local L = self:LogInit()
+    L.pos = (L.pos or 0) + 1
+    local slot = math.mod(L.pos - 1, L.max) + 1
+    L.entries[slot] = string.format("%.2f|%s", GetTime() - (L.t0 or 0), text)
+end
+
+-- True when anything wants trace output - chat, the press log, or both. The
+-- class modules build their trace strings inside a guard so the concatenation
+-- is skipped entirely when nobody is listening; that guard MUST use this and
+-- not self.trace, or enabling only the log records nothing (the string is
+-- never built, so Trace is never even called).
+function Aegis_SBR:Tracing()
+    return (self.trace or self.logging) and true or false
+end
+
+-- Chat trace and the press log are independent on purpose: the chat line is
+-- throttled to stay readable while playing, but the log wants EVERY press or
+-- the CP distribution it is meant to answer would be a biased sample.
+-- Only the FIRST line is logged. Callers pass the per-press state line first and
+-- any supplementary diagnostics after it; those extras are static for a whole
+-- session (the rogue's "rank: ..." line, for instance, never changes while
+-- playing), so recording them once per press doubled both the file size and the
+-- number of ring slots burned, for nothing. They stay in the chat trace, which
+-- is where they are actually useful.
 function Aegis_SBR:Trace(...)
+    if not self.trace and not self.logging then return end
+    if self.logging and arg[1] then self:LogWrite(arg[1]) end
     if not self.trace then return end
     local now = GetTime()
     if now - (self.traceT or 0) < 0.4 then return end
@@ -788,6 +848,39 @@ function Aegis_SBR:EvalCommand(msg)
         msgOut("trace " .. (self.trace and "on (per-press log)" or "off"))
         return
     end
+    if cmd == "log" then
+        local sub = string.lower(t[2] or "")
+        -- Read the current state WITHOUT creating the table: only "on" and
+        -- "clear" may bring AegisLog into existence, so merely asking for the
+        -- status never leaves a saved variable behind on a machine that has
+        -- never recorded anything.
+        local have = (type(AegisLog) == "table") and AegisLog or nil
+        local cap = (have and have.max) or LOG_MAX
+        local held = (have and have.pos) or 0
+        if held > cap then held = cap end
+        if sub == "on" then
+            self:LogInit()
+            self.logging = true
+            AegisLog.enabled = true
+            msgOut("press log ON - every press is recorded (chat trace is separate).")
+            msgOut("Run your test, then /reload to write the file, then read it from:", 0.7, 0.7, 0.7)
+            msgOut("WTF\\Account\\<ACCOUNT>\\<Realm>\\<Char>\\SavedVariables\\Aegis_SBR.lua", 0.7, 0.7, 0.7)
+        elseif sub == "off" then
+            self.logging = false
+            if have then have.enabled = false end
+            msgOut("press log OFF. " .. held .. " lines held - /reload to write them out.")
+            msgOut("They are dropped on the load AFTER that, so the saved file does not keep them forever.", 0.7, 0.7, 0.7)
+        elseif sub == "clear" then
+            self:LogInit(true)
+            msgOut("press log cleared.")
+        else
+            msgOut("press log is " .. (self.logging and "ON" or "off")
+                .. ", holding " .. held .. " of " .. cap .. " lines"
+                .. (((have and have.pos) or 0) > cap and " (oldest overwritten)" or "") .. ".")
+            msgOut("usage: /sbr log on|off|clear  - NOT written to disk until /reload or logout.", 0.7, 0.7, 0.7)
+        end
+        return
+    end
     if cmd == "ui" or cmd == "config" then
         if self.active and self.active.OpenConfig then self.active:OpenConfig()
         else msgOut("no configuration UI for this class yet.", 1, 0.5, 0.3) end
@@ -800,6 +893,10 @@ function Aegis_SBR:EvalCommand(msg)
         return
     end
 
+    -- `log` is intentionally absent from this list: it is a development aid for
+    -- capturing a rotation trace to file, not something a player has any use
+    -- for. It still works when typed, so it can be handed out on request when
+    -- diagnosing a report ("/sbr log on, play a bit, /reload, send me the file").
     msgOut("commands: ui, list, use, off, new, del, check, reset, acquire, minimap, debug, talents, trace (plus class commands).")
 end
 
@@ -815,6 +912,22 @@ function Aegis_SBR:OnAddonLoaded()
     if (type(AegisDB) ~= "table" or not next(AegisDB)) and type(AutoRotaDB) == "table" then
         AegisDB = AutoRotaDB
         AegisDB._migratedFrom = "AutoRotaDB"
+    end
+    -- Press log: a development tool, not a player feature. It is deliberately
+    -- NOT initialised here - AegisLog is created lazily, on the first /sbr log
+    -- on. A player who never touches the command therefore never gets the
+    -- variable created and never carries it in their saved file; the table
+    -- below is only ever touched if one already exists from a previous session.
+    --
+    -- The log survives /reload on purpose: /reload is exactly what flushes it
+    -- to disk, so clearing it there would destroy the recording at the moment
+    -- the user is trying to save it. Entries are dropped one load AFTER
+    -- logging is switched off, so a finished test does not linger forever.
+    if type(AegisLog) == "table" then
+        self.logging = AegisLog.enabled and true or false
+        if not self.logging and type(AegisLog.entries) == "table" and next(AegisLog.entries) then
+            self:LogInit(true)
+        end
     end
     local _, class = UnitClass("player")
     self.active = self.classes[class]

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -3,7 +3,7 @@
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
 ## Version: 1.1.0
-## SavedVariablesPerCharacter: AegisDB, AutoRotaDB
+## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog
 
 Aegis_SBR.lua
 Aegis_SBR_UI.lua

--- a/classes/Class_Druid.lua
+++ b/classes/Class_Druid.lua
@@ -299,7 +299,7 @@ function M:RotateCat(cfg)
 
     self:EnsureMeleeSwing()
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("cat style=" .. (cfg.catStyle or "bleed")
             .. " energy=" .. energy .. " cp=" .. cp
             .. " prowl=" .. (self:HasBuff("Prowl") and "Y" or "N")
@@ -370,7 +370,7 @@ function M:RotateBear(cfg)
 
     self:EnsureMeleeSwing()
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("bear rage=" .. rage
             .. " def=" .. (self.hpDefenseActive and "Y" or "N")
             .. " FF=" .. (cfg.ffBear and (self:DebuffUp("Faerie Fire (Feral)") and "Y" or "n") or "-")
@@ -424,7 +424,7 @@ end
 function M:RotateCaster(cfg)
     local side = cfg.eclipse and self:EclipseSide() or nil
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("caster nuke=" .. (cfg.nuke or "Wrath")
             .. " MF=" .. (cfg.useMoonfire and (self:DebuffUp("Moonfire") and "Y" or "n") or "-")
             .. " IS=" .. (cfg.useInsectSwarm and (self:DebuffUp("Insect Swarm") and "Y" or "n") or "-")
@@ -681,7 +681,7 @@ function M:RotateResto(cfg)
     -- Heals only cast in caster form; drop any shapeshift first (no Tree auto-shift).
     local form = self:CurrentForm()
     if form then
-        if self.trace then self:Trace("resto: dropping " .. form .. " to cast") end
+        if self:Tracing() then self:Trace("resto: dropping " .. form .. " to cast") end
         self:CastSafe(form)
         return
     end
@@ -778,7 +778,7 @@ function M:Rotate(cfg)
     if self.hpDefenseActive then
         if not inBear then
             local b = self:BearFormSpell()
-            if self.trace then self:Trace("DEFENSE: hp " .. string.format("%.0f", self:PlayerHPPct()) .. "%, shifting to " .. b) end
+            if self:Tracing() then self:Trace("DEFENSE: hp " .. string.format("%.0f", self:PlayerHPPct()) .. "%, shifting to " .. b) end
             self:CastSafe(b)
             return
         end
@@ -799,7 +799,7 @@ function M:Rotate(cfg)
     else
         if cfg.form == "caster" then
             if self:KnowsSpell("Moonkin Form") then
-                if self.trace then self:Trace("entering Moonkin Form") end
+                if self:Tracing() then self:Trace("entering Moonkin Form") end
                 self:CastSafe("Moonkin Form")
                 return
             end
@@ -808,7 +808,7 @@ function M:Rotate(cfg)
         end
         local want = self:PreferredFormSpell(cfg)
         if want then
-            if self.trace then self:Trace("caster form, shifting into " .. want) end
+            if self:Tracing() then self:Trace("caster form, shifting into " .. want) end
             self:CastSafe(want)
         else
             -- no combat form learned yet: the caster loop carries level 1+

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -583,7 +583,7 @@ function M:Rotate(cfg)
     -- Resolve smart sting (Viper > Serpent) to the effective sting for this target
     local effectiveSting = self:ResolveSting(cfg)
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("mode=" .. (cfg.mode or "ranged") .. (cfg.mode == "auto" and ("/" .. (melee and "melee" or "ranged")) or "")
             .. " hp=" .. floor(targetHP)
             .. " sting=" .. (cfg.sting ~= "" and (cfg.sting

--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -1025,7 +1025,7 @@ function M:Rotate(cfg)
         if self:HealSeals(cfg) then return end
     end
 
-    if self.trace then
+    if self:Tracing() then
         local db = cfg.seals.debuff
         local strk = (self:StrikeEnabled(cfg) and self:SharedStrikeReady(cfg)) and "Y" or "N"
         self:Trace(

--- a/classes/Class_Rogue.lua
+++ b/classes/Class_Rogue.lua
@@ -34,8 +34,31 @@ local function msgOut(text, r, g, b) Aegis_SBR:Msg(text, r, g, b) end
 -- is needed for any of them (previously SnD and Envenom used a hardcoded
 -- duration table stamped at cast time; that guess is gone now that the real
 -- timer reads back reliably).
+--
+-- Reading the live timer is also why no duration table is maintained here any
+-- more - but the underlying numbers still matter when reasoning about upkeep
+-- cost, so they live in docs/turtle-mechanics.md (Rogue section) instead of
+-- being re-derived. The one that bites: Turtle's SnD duration talent is called
+-- **Improved Blade Tactics** (not "Improved Slice and Dice"), +45% at 3/3, and
+-- the spell tooltip shows only the BASE duration - so a talented rogue's Slice
+-- and Dice really lasts 13.05-30.45s, not the 9-21s the tooltip implies.
 local TALENT_TASTE = "Taste for Blood"
-local BUFF_RENEW = 5    -- a buff counts as expiring soon below this remaining time
+-- Default renew window: seconds of remaining buff time at or below which Slice
+-- and Dice / Envenom are re-applied. Overridable per profile via cfg.buffRenew.
+-- This used to be 5, sized for the era when the remaining time was ESTIMATED
+-- from a stamped duration table - a wide margin was right when the number could
+-- be wrong. Now that the real timer is read (see the header), that justification
+-- is gone and 5s was simply throwing away up to a sixth of the buff's life, and
+-- with it the combo points that paid for it. Lower is more efficient; too low
+-- risks dropping the buff, because at 0 combo points the refresh needs TWO
+-- presses (a builder first), which on an energy-starved rogue can take several
+-- seconds. 0 means "only once it has actually dropped" - hence the <= test at
+-- the call site, so a fully expired buff (BuffTime returns 0) still qualifies.
+-- 1 is measured, not guessed: a 2 minute press log at this setting refreshed
+-- with an average of 0.64s left on the buff, never dropped Slice and Dice, and
+-- lost Envenom only three times for ~2.4s combined (2% downtime) - far less
+-- than the up-to-4s of buff life the old 5 threw away on every single refresh.
+local BUFF_RENEW = 1
 -- Taste for Blood gets a wider renew window than the other two buffs: Slice and
 -- Dice and Envenom can be refreshed at any combo point, while Rupture waits for
 -- its own (higher) point threshold, so its opportunity comes around far less
@@ -51,7 +74,7 @@ M.templates = {
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
         useSurpriseAttack = false,
         useExecute = false, executeHpPct = 10, evisExecuteOnly = false, ruptureCP = 3,
-        cpFinish = 4, popCDs = false, autoCDElite = false,
+        cpFinish = 4, buffRenew = 1, useColdBlood = false, popCDs = false, autoCDElite = false,
     },
     assassination = {
         builder = "", useSnd = true, useEnvenom = true, useRupture = true, useRiposte = true,
@@ -61,13 +84,13 @@ M.templates = {
         -- keep-the-stronger-one logic - so anything below 5 risks replacing an existing 10%
         -- buff with a weaker one the moment Rupture comes due (Discord-reported, confirmed).
         useExecute = false, executeHpPct = 10, evisExecuteOnly = false, ruptureCP = 5,
-        cpFinish = 4, popCDs = false, autoCDElite = false,
+        cpFinish = 4, buffRenew = 1, useColdBlood = false, popCDs = false, autoCDElite = false,
     },
     combat = {
         builder = "", useSnd = true, useEnvenom = false, useRupture = false, useRiposte = false,
         useSurpriseAttack = true,
         useExecute = false, executeHpPct = 10, evisExecuteOnly = false, ruptureCP = 3,
-        cpFinish = 5, popCDs = false, autoCDElite = true,
+        cpFinish = 5, buffRenew = 1, useColdBlood = false, popCDs = false, autoCDElite = true,
     },
 }
 
@@ -104,6 +127,12 @@ function M:NormalizeProfile(c)
     -- combo point goes into the maintained buffs instead.
     if c.evisExecuteOnly == nil then c.evisExecuteOnly = false end
     if c.cpFinish == nil then c.cpFinish = 4 end
+    -- Renew window for Slice and Dice / Envenom, in seconds of remaining time.
+    -- Existing profiles are moved off the old hardcoded 5 deliberately: that
+    -- value only ever existed to cover an estimated timer we no longer use.
+    if c.buffRenew == nil then c.buffRenew = BUFF_RENEW end
+    -- Cold Blood: opt-in. Rides along with Eviscerate only (see ColdBloodBefore).
+    if c.useColdBlood == nil then c.useColdBlood = false end
     if c.popCDs == nil then c.popCDs = false end
     if c.autoCDElite == nil then c.autoCDElite = false end
     -- old keys from any earlier format are dropped silently
@@ -184,6 +213,25 @@ function M:RuptureDue()
     return not self:TargetDebuffUp("Rupture", "Ability_Rogue_Rupture")
 end
 
+-- Fire Cold Blood immediately before the Eviscerate it is meant to turn into a
+-- crit. Confirmed in game that it costs no global cooldown, so both go out in
+-- the same press - and that is the whole point: the buff applies to the NEXT
+-- Sinister Strike, Backstab, Ambush, Noxious Assault or Eviscerate, and
+-- Noxious Assault is a BUILDER. Popped at any other moment it is eaten by the
+-- next builder for a fraction of the payoff, so it is deliberately not a
+-- priority step of its own - it only ever rides along with a finisher.
+-- Gated on cpFinish rather than a threshold of its own: that setting already
+-- means "enough points for Eviscerate to be worth it", and it keeps the 3
+-- minute cooldown off the execute finisher, which fires with whatever is on
+-- hand (often 1-2 points) and would waste the crit.
+function M:ColdBloodBefore(cfg, cp)
+    if not cfg.useColdBlood then return end
+    if cp < (cfg.cpFinish or 4) then return end
+    if not self:KnowsSpell("Cold Blood") then return end
+    if not self:OwnCDReady("Cold Blood") then return end
+    CastSpellByName("Cold Blood")
+end
+
 -- ============================================================
 -- Rotation. The core has already secured a target and ensured auto attack.
 -- Cooldowns are off the global cooldown, so they may be cast in the same
@@ -217,7 +265,7 @@ function M:Rotate(cfg)
     -- finisher, so this is rarely blocked once a fight is underway).
     local execute = cfg.useExecute and cp >= 1 and self:TargetHPPct() <= (cfg.executeHpPct or 10)
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("cp=" .. cp
             .. " build=" .. builder
             .. " snd=" .. (useSnd and string.format("%.1fs", self:BuffTime("Slice and Dice")) or "-")
@@ -228,6 +276,8 @@ function M:Rotate(cfg)
             .. " rip=" .. ((cfg.useRiposte and now < (self.riposteExpiry or 0)) and "Y" or "N")
             .. " sa=" .. ((cfg.useSurpriseAttack and now < (self.surpriseExpiry or 0)) and "Y" or "N")
             .. " exec=" .. (cfg.useExecute and (execute and "Y" or "N") or "-")
+            .. " cb=" .. (cfg.useColdBlood and (self:KnowsSpell("Cold Blood")
+                and (self:OwnCDReady("Cold Blood") and "rdy" or "cd") or "?") or "-")
             .. " elite=" .. (isElite and "Y" or "N"),
             -- Rogue never downranks (all ranks cost the same energy), so every
             -- Cast() below is a bare CastSpellByName(name) - vanilla resolves
@@ -268,8 +318,13 @@ function M:Rotate(cfg)
     -- off the real buff timer now (see the header comment above).
     local sndLeft = useSnd and self:BuffTime("Slice and Dice") or 0
     local envLeft = useEnv and self:BuffTime("Envenom") or 0
-    local sndDue = useSnd and sndLeft < BUFF_RENEW
-    local envDue = useEnv and envLeft < BUFF_RENEW
+    -- 0 is a meaningful setting here ("wait until it has actually dropped"), and
+    -- 0 is truthy in Lua, so the `or` fallback only fires for a genuinely unset
+    -- field. The test is <= rather than < so that a lapsed buff, which reads as
+    -- 0 seconds remaining, still counts as due when the window is set to 0.
+    local renew = cfg.buffRenew or BUFF_RENEW
+    local sndDue = useSnd and sndLeft <= renew
+    local envDue = useEnv and envLeft <= renew
     local rupDue = useRup and self:RuptureDue()
     local rupCP = cfg.ruptureCP or 3
 
@@ -278,6 +333,7 @@ function M:Rotate(cfg)
     -- points go straight into damage.
     -- ------------------------------------------------------------
     if execute then
+        self:ColdBloodBefore(cfg, cp)
         self:Cast("Eviscerate")
         return
     end
@@ -319,6 +375,7 @@ function M:Rotate(cfg)
     -- into the buffs instead.
     -- ------------------------------------------------------------
     if not cfg.evisExecuteOnly and not rupDue and cp >= cpEvis then
+        self:ColdBloodBefore(cfg, cp)
         self:Cast("Eviscerate")
         return
     end

--- a/classes/Class_Rogue_UI.lua
+++ b/classes/Class_Rogue_UI.lua
@@ -32,6 +32,8 @@ function M:BuildBody(ui, parent)
     L:Header("Finishers")
     self.sndRow = L:Row{ key = "useSnd", label = "Slice and Dice", spell = "Slice and Dice", onToggle = set("useSnd") }
     self.envRow = L:Row{ key = "useEnvenom", label = "Envenom", spell = "Envenom", onToggle = set("useEnvenom") }
+    self.renewRow = L:Row{ label = "Refresh the two above at",
+        slider = { key = "buffRenew", min = 0, max = 2, step = 1, suffix = "s", onChange = set("buffRenew") } }
     self.rupRow = L:Row{ key = "useRupture", label = "Rupture at CP", spell = "Rupture", onToggle = set("useRupture"),
         slider = { key = "ruptureCP", min = 1, max = 5, step = 1, suffix = "", onChange = set("ruptureCP") } }
     self.cpRow = L:Row{ label = "Eviscerate at CP",
@@ -41,6 +43,7 @@ function M:BuildBody(ui, parent)
         slider = { key = "executeHpPct", min = 1, max = 30, step = 1, suffix = "%", onChange = set("executeHpPct") } }
 
     L:Header("Cooldowns")
+    self.cbRow = L:Row{ key = "useColdBlood", label = "Cold Blood with Eviscerate", spell = "Cold Blood", onToggle = set("useColdBlood") }
     self.cdRow = L:Row{ key = "popCDs", label = "Pop cooldowns", onToggle = set("popCDs") }
     self.cdEliteRow = L:Row{ key = "autoCDElite", label = "Auto on elite", onToggle = set("autoCDElite") }
 
@@ -79,12 +82,14 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.ripRow.cb, "Riposte", "Cast right after a parry, inside the short Riposte window. Neither spends nor builds combo points.")
     ui:Tip(self.sndRow.cb, "Slice and Dice", "Kept up: refreshed cheaply at 1 combo point, dumped with Eviscerate above that.")
     ui:Tip(self.envRow.cb, "Envenom", "Kept up the same way as Slice and Dice (Turtle ability).")
+    ui:Tip(self.renewRow.slider, "Refresh buffs at", "Seconds of remaining time at which Slice and Dice and Envenom are re-applied. Whatever is left on the buff at that moment is thrown away, so a lower value wastes fewer combo points.", "1 is the measured sweet spot: refreshes land with ~0.6s to spare and the buffs practically never drop. 2 buys a little more safety on low energy, where a refresh at 0 combo points needs TWO presses (a builder first). 0 waits for the buff to actually lapse - most efficient, but the downtime is real.")
     ui:Tip(self.rupRow.cb, "Rupture", "With the Assassination talent Taste for Blood it is kept up for that melee-damage BUFF (not the bleed) and takes priority over the other finishers. Without the talent it simply maintains the bleed on your target.", "The slider is its own combo-point threshold, separate from Eviscerate's on purpose: only Rupture's payoff scales with the points spent (2% damage per point), and sharing Eviscerate's higher threshold meant it never got cast at all.")
     ui:Tip(self.rupRow.slider, "Rupture at CP", "Combo points required before Rupture is cast. Lower = renewed more reliably but a weaker buff; higher = stronger buff but it may never be reached, since every buff refresh resets you to 1 point.", "Recommended: 5. A recast simply overwrites the buff at whatever combo points it was cast with, so anything below 5 risks replacing an existing 10% Taste for Blood buff with a weaker one the moment Rupture comes due.")
     ui:Tip(self.evisOnlyRow.cb, "Eviscerate only in execute", "Reserve Eviscerate for the execute phase, so every other combo point goes into maintaining your buffs instead of direct damage.", "Useful once you maintain several buffs: refreshes keep resetting your points, so a normal Eviscerate threshold is rarely reached anyway.")
     ui:Tip(self.cpRow.slider, "Finisher combo points", "Eviscerate is used once combo points reach this number.", "Greyed out while \"Eviscerate only in execute\" is on, since that setting bypasses this threshold entirely.")
     ui:Tip(self.execRow.cb, "Execute low-HP targets", "Below the health value on the right, Eviscerate fires with whatever combo points are on hand (at least 1) instead of waiting for the normal threshold.", "Ruthlessness guarantees a combo point after any finisher, so this rarely goes unused once a fight is underway.")
     ui:Tip(self.execRow.slider, "Execute below", "Target health percent under which Eviscerate finishes early rather than risk combo points going to waste on a kill.")
+    ui:Tip(self.cbRow.cb, "Cold Blood with Eviscerate", "Fires Cold Blood in the same press, right before Eviscerate, so the guaranteed crit lands on your biggest hit. Costs no global cooldown.", "Deliberately tied to Eviscerate rather than used on cooldown: the buff is spent by the next Sinister Strike, Backstab, Ambush, Noxious Assault OR Eviscerate - and Noxious Assault is a builder, so a Cold Blood popped at any other moment is eaten by a builder for a fraction of the damage. Skipped when combo points are below the Eviscerate threshold, so the execute finisher cannot waste the 3 minute cooldown on 1-2 points.")
     ui:Tip(self.cdRow.cb, "Pop cooldowns", "Use Adrenaline Rush and Blade Flurry every press (off the global cooldown).")
     ui:Tip(self.cdEliteRow.cb, "Auto on elite", "Pop the cooldowns only against elite and boss targets.")
     ui:Tip(self.pcRow.cb, "Poison control", "Master switch for the poison Quick Bar and rebuff buttons (also in the minimap right-click menu). Applies to this character across all rogue profiles.", "Applying a poison needs a real click, so it is always button-driven, never cast from the rotation macro.")
@@ -116,6 +121,7 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.rupRow, buf.useRupture)
     ui:BindCheck(self.ripRow, buf.useRiposte)
     ui:BindCheck(self.saRow, buf.useSurpriseAttack)
+    ui:BindCheck(self.cbRow, buf.useColdBlood)
     ui:BindCheck(self.cdRow, buf.popCDs)
     ui:BindCheck(self.cdEliteRow, buf.autoCDElite)
 
@@ -126,6 +132,15 @@ function M:RefreshBody(ui, buf)
     local rupv = buf.ruptureCP or 3
     self.rupRow.slider:SetValue(rupv)
     if self.rupRow.slider.valText then self.rupRow.slider.valText:SetText(tostring(rupv)) end
+
+    -- 0 is a valid setting ("only once it has dropped"), so this must not use
+    -- `or` with a non-zero fallback - that would silently turn 0 into 3.
+    local renewv = buf.buffRenew
+    if renewv == nil then renewv = 1 end
+    self.renewRow.slider:SetValue(renewv)
+    if self.renewRow.slider.valText then self.renewRow.slider.valText:SetText(renewv .. "s") end
+    -- Only meaningful while at least one of the two buffs it governs is on.
+    ui:SliderEnable(self.renewRow.slider, (buf.useSnd or buf.useEnvenom) and true or false)
 
     ui:BindCheck(self.evisOnlyRow, buf.evisExecuteOnly)
     ui:SliderEnable(self.cpRow.slider, not buf.evisExecuteOnly)

--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -653,7 +653,7 @@ function M:RotateEnhancement(cfg)
     local shock = self:ShockSpell(cfg)
     local cc = self:HasClearcast() and self:ClearcastUp()
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("enh shock=" .. (shock ~= "" and shock or "-")
             .. " ss=" .. (cfg.useStormstrike and (self:KnowsSpell("Stormstrike") and "Y" or "n") or "-")
             .. " ls=" .. (cfg.useLightningStrike and (self:KnowsSpell("Lightning Strike") and "Y" or "n") or "-")
@@ -708,7 +708,7 @@ end
 function M:RotateElemental(cfg)
     local cc = self:HasClearcast() and self:ClearcastUp()
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("ele shock=" .. (self:ShockSpell(cfg) ~= "" and self:ShockSpell(cfg) or "-")
             .. " cc=" .. (cc and "Y" or "n")
             .. " EM=" .. (cfg.useElementalMastery and (self:KnowsSpell("Elemental Mastery") and "Y" or "n") or "-")
@@ -754,7 +754,7 @@ function M:RotateTank(cfg)
     self:EnsureMeleeSwing()
     local shock = self:ShockSpell(cfg)
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("tank shock=" .. (shock ~= "" and shock or "-")
             .. " ss=" .. (cfg.useStormstrike and (self:KnowsSpell("Stormstrike") and "Y" or "n") or "-")
             .. " ls=" .. (cfg.useLightningStrike and (self:KnowsSpell("Lightning Strike") and "Y" or "n") or "-")

--- a/classes/Class_Warlock.lua
+++ b/classes/Class_Warlock.lua
@@ -548,7 +548,7 @@ function M:ApplyDot(spellName, texFrag, interval)
     local id = self:TargetId()
     local rec = self.dotThrottle[spellName]
     local now = GetTime()
-    if self.trace then
+    if self:Tracing() then
         local throttleAge = (rec and rec.id == id and rec.t) and (now - rec.t) or -1
         local pend = self.dotPending[spellName]
         local pendAge = (pend and pend.id == id) and (now - pend.t) or -1
@@ -686,7 +686,7 @@ function M:Rotate(cfg)
         end
         if self:HasWand() then
             if self:Wanding() then return end
-            if self.trace then
+            if self:Tracing() then
                 self:Trace(string.format("wandstart ready=%s mana=%.0f hp=%.0f",
                     tostring(self:IsReady("Shoot")), self:ManaPct(), hp))
             end
@@ -748,7 +748,7 @@ function M:Rotate(cfg)
     local dotStopHp = cfg.dotStopHp or 0
     local dotsSuppressed = dotStopHp > 0 and thp <= dotStopHp
 
-    if self.trace then
+    if self:Tracing() then
         local up = ""
         for i = 1, table.getn(order) do
             local sp, tex = order[i][1], order[i][2]
@@ -806,7 +806,7 @@ function M:Rotate(cfg)
             -- cast record for this target) is not treated as urgent, so the
             -- channel is not blocked on a guess.
             local minRemain = self:DHMinDotRemain()
-            if self.trace then
+            if self:Tracing() then
                 local id = self:TargetId()
                 for i = 1, table.getn(order) do
                     local sp = order[i][1]

--- a/classes/Class_Warrior.lua
+++ b/classes/Class_Warrior.lua
@@ -318,7 +318,7 @@ function M:Rotate(cfg)
     local inExecute = cfg.useExecute and hp <= 20 and self:KnowsSpell("Execute")
         and rage >= RAGE["Execute"] and not self:InStance("Defensive Stance")
 
-    if self.trace then
+    if self:Tracing() then
         self:Trace("rage=" .. rage
             .. " stance=" .. (self:CurrentStanceName() or "-")
             .. " hp=" .. string.format("%.0f", hp)

--- a/docs/turtle-mechanics.md
+++ b/docs/turtle-mechanics.md
@@ -83,6 +83,45 @@ forum.turtlecraft.gg theorycraft threads, r/turtlewow, community class guides.
   after dodge, unblockable. **Combo points reset (not lost) on target switch.** Blade Rush
   scales energy regen with agility. Rogues can wield 1H axes.
 
+### Finisher numbers (in-game tooltips, confirmed)
+All three upkeep finishers cost **20 energy** — do NOT assume the vanilla 25/35 values.
+- **Slice and Dice** (Rank 2): +30% melee attack speed. Base 9/12/15/18/21s for 1-5 CP.
+- **Envenom** (Assassination talent): +30% poison effectiveness **and** +30% application
+  chance. 12/16/20/24/28s for 1-5 CP. **Not** extended by Improved Blade Tactics.
+- **Rupture** (Rank 6): 272/380/504/644/**800** damage over 8/10/12/14/**16**s for 1-5 CP.
+- **Eviscerate**: cost not yet captured; assumed higher than the 20 above.
+
+### Improved Blade Tactics (Assassination) — Turtle's SnD duration talent
+There is **no "Improved Slice and Dice"** in Turtle; the equivalent is **Improved Blade
+Tactics**, 3 ranks, **+45% duration** at 3/3 on *Slice and Dice and Flourish* (tooltip
+confirmed). The spell tooltip shows BASE durations, so the talent is invisible there.
+At 3/3 the real SnD durations are **13.05 / 17.4 / 21.75 / 26.1 / 30.45s** for 1-5 CP.
+Easy to miss because the talent name gives no hint, and it changes the upkeep maths
+completely — a 5-CP refresh lasts more than twice a 1-CP one.
+
+### Taste for Blood (Assassination, 2 ranks) — tooltip confirmed at 2/2
+Extends Rupture's duration by **6s** and grants **+2% melee damage per combo point** for
+that full duration, *"regardless of successful application"* (so a resisted/dodged Rupture
+still buffs). At 5 CP that is **+10% melee damage for 22s**. Note **melee** — it does not
+touch poison damage, which is where a poison build's damage actually lives (below).
+
+### Measured damage split (full dungeon, lvl-60 Assassination/poison build)
+1,209,897 damage, 388.4 DPS. Instant Poison VI **66.2%** · Auto Hit **13.8%** · Noxious
+Assault **10.9%** · Eviscerate **7.5%** · Rupture **0.8%** · rest negligible.
+Consequences for rotation design on this kind of build:
+- **Poisons are two thirds of the damage.** Anything that adds weapon swings or poison
+  application is a multiplier on the main damage source: Slice and Dice (+30% swings),
+  Envenom (+30% effectiveness and application), and **Noxious Assault, which guarantees
+  poison application from BOTH weapons** — its real contribution is far larger than the
+  10.9% the meter credits it, because the procs it forces are booked under the poison.
+- **Taste for Blood can only lift the melee buckets** (Auto Hit + Noxious Assault +
+  Eviscerate ~ 32%), so even at 100% uptime it is worth ~3% overall — and Rupture's own
+  DoT measured 0.8%. On short-lived trash, where the 16s DoT never ticks out, Rupture is
+  not worth its 5-CP peak; on a boss it is a different calculation.
+- Profile used for the measurement: builder Noxious Assault, cpFinish 5, ruptureCP 5,
+  `evisExecuteOnly` ON, execute at 20%, SnD + Envenom + Rupture all maintained, cooldowns
+  off. Keep this as the baseline when A/B testing rotation changes.
+
 ## Priest
 - **Discipline reworked into holy-damage support DPS** (Smite/Holy Fire focus). **PW:Shield
   castable in Shadowform.** **Proclaim Champion** (Holy capstone): tank buff (DR, resist,


### PR DESCRIPTION
Two commits. The first adds a development tool for capturing a rotation trace to file; the second uses what that tool measured to fix a rogue upkeep setting that had been wrong since the buff timers were reworked. Both verified in game.

Order matters if you check them out singly: `Class_Rogue.lua` in commit 2 calls `Aegis_SBR:Tracing()`, which commit 1 introduces.

## 1 — Press log (`/sbr log on|off|clear`)

Records one line per rotation press into a new `AegisLog` saved variable, flushed to `WTF\...\SavedVariables\Aegis_SBR.lua` on `/reload` or logout.

The 1.12 sandbox has **no file access at all** — no `io`, no `os`, and neither SuperWoW nor Nampower adds any — so a saved variable is the only route off the client. Kept out of `AegisDB` so a large log can never bloat or endanger profile data, and so it can be cleared on its own. Implemented as a true ring buffer (wrapping write index, 2000 lines); `table.remove(t, 1)` would shift every entry on every press, inside the rotation's hot path.

### The guard fix is what made it work

All seven class modules build their trace strings behind `if self.trace then`, to skip the concatenation when nobody is listening. Hooking the log inside `Trace()` was therefore dead code unless the chat trace happened to be on as well. Added `Aegis_SBR:Tracing()` (true when chat trace **or** logging is active) and moved all 18 guards onto it. This only changes *when the string is built* — no rotation behaviour changes.

Chat trace and log stay independent on purpose: the chat line keeps its 0.4s throttle to stay readable while playing; the log takes every press, because a throttled sample would bias exactly the distributions it exists to measure.

### Zero footprint for anyone not using it

`AegisLog` is created lazily on the first `/sbr log on`, never at load — a player who never touches the command never carries the variable. Entries are dropped one load after logging is switched off, and `log` is deliberately absent from the `/sbr` command list. It is a development aid, useful to hand out on request when diagnosing a report.

## 2 — Rogue: buff-renew window, Cold Blood, mechanics recorded

**Renew window is now a slider (0–2s), default 1**, replacing a hardcoded 5.

The 5 was never a considered value. It was sized for the era when remaining buff time was *estimated* from a stamped duration table, where a wide margin covered a number that could simply be wrong. Reading the real timer removed that justification, but the constant was never revisited — so every refresh threw away up to 4s of buff life, and the combo points that bought it.

**1 is measured, not guessed.** A 2-minute press log at that setting:

| | |
|---|---|
| Remaining on refresh | Ø **0.64s** (max 1.0s) |
| Slice and Dice dropped | **0×** |
| Envenom dropped | 3× for ~2.4s combined (2% downtime) |

Two subtleties worth a look in review: the test is `<=` rather than `<`, because 0 is a valid setting meaning "wait until it has actually lapsed" and an expired buff reads as 0 seconds remaining. For the same reason the UI reads the field without an `or` fallback — `buf.buffRenew or 1` would silently turn a deliberate 0 into 1.

**Cold Blood** (opt-in, off by default) fires in the same press immediately before Eviscerate. Deliberately *not* a priority step of its own: the buff is spent by the next Sinister Strike, Backstab, Ambush, **Noxious Assault** or Eviscerate — and Noxious Assault is a builder, so popping it on cooldown feeds the guaranteed crit to a builder for a fraction of the payoff. Confirmed in game that it costs no GCD. Gated on `cpFinish` rather than a threshold of its own, which also keeps the 3-minute cooldown off the execute finisher, which fires with whatever is on hand and would waste it on 1–2 points. Adds a `cb=` trace field.

**`docs/turtle-mechanics.md`** gains a Rogue section with numbers that kept being re-derived and re-lost:

- All three upkeep finishers cost **20 energy** — not the vanilla 25/35.
- **Improved Blade Tactics** is Turtle's Slice and Dice duration talent (+45% at 3/3). Easy to miss: the name gives no hint, and the spell tooltip shows only the base duration. A talented rogue's SnD really lasts **13.05–30.45s**, not the 9–21s the tooltip implies — which changes the upkeep maths completely.
- Real Rupture / Envenom / SnD duration tables, and Taste for Blood's actual wording (2%/CP on **melee**, +6s Rupture duration, applies regardless of successful application).
- A measured dungeon damage split as a baseline: Instant Poison **66.2%**, Auto Hit 13.8%, Noxious Assault 10.9%, Eviscerate 7.5%, Rupture **0.8%** — plus what follows from it for rotation design on a poison build.

## Notes

- `scripts/verify.py --all` green.
- No version bump, per the existing pattern of feature commits followed by a separate `Cut vX.Y.Z`.
- Line endings: some edits were scripted and landed as LF; git normalised them back to CRLF on staging, so the diffs contain only real changes (checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)