### PR TITLE
Paladin: let Consecration opt out of the mana-recovery hold, cache creature type

### DIFF
--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -136,6 +136,7 @@ end
 M.templates = {
     starter = {  -- valid for a brand new paladin (only Seal of Righteousness)
         seals = { debuff = "", damage = "Seal of Righteousness" },
+        consecInMana = false,
         manaManage = false, manaLow = 30, manaHigh = 70,
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "autodps",
@@ -143,6 +144,7 @@ M.templates = {
     },
     retri = {
         seals = { debuff = "Seal of the Crusader", damage = "Seal of Righteousness" },
+        consecInMana = false,
         manaManage = false, manaLow = 30, manaHigh = 70,
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "autodps",
@@ -150,6 +152,7 @@ M.templates = {
     },
     prot = {
         seals = { debuff = "Seal of the Crusader", damage = "Seal of Righteousness" },
+        consecInMana = false,
         manaManage = false, manaLow = 30, manaHigh = 70,
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "tankblock",
@@ -157,6 +160,7 @@ M.templates = {
     },
     heal = {  -- group healer: heals the party/raid, keeps Seal of Wisdom for mana
         seals = { debuff = "", damage = "" },
+        consecInMana = false,
         manaManage = false, manaLow = 30, manaHigh = 70,
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "autodps",
@@ -236,6 +240,8 @@ function M:NormalizeProfile(c)
         if c.spells[sk[i]] == nil then c.spells[sk[i]] = false end
     end
 
+    -- Let Consecration ignore the mana-recovery hold (see the rotation step).
+    if c.consecInMana == nil then c.consecInMana = false end
     if c.manaManage == nil then c.manaManage = false end
     if c.manaLow  == nil then c.manaLow  = 30 end
     if c.manaHigh == nil then c.manaHigh = 70 end
@@ -581,10 +587,20 @@ function M:DesiredOpenerSeal(cfg)
     return nil
 end
 
--- Exorcism only works on Undead and Demon targets.
+-- Exorcism only works on Undead and Demon targets. The creature type cannot
+-- change under a given target, so it is resolved once per target rather than on
+-- every press - the check sits in the rotation's hot path and this is a plain
+-- API call saved on all but the first press against each mob. Keyed by target
+-- id (GUID based, so same-named mobs are told apart), which also means a target
+-- swap re-reads immediately instead of answering from a stale cache.
 function M:TargetIsUndeadOrDemon()
-    local t = UnitCreatureType("target")
-    return t == "Undead" or t == "Demon"
+    local id = self:TargetId()
+    if id ~= self.creatureTypeId then
+        local t = UnitCreatureType("target")
+        self.creatureTypeId = id
+        self.creatureTypeUD = (t == "Undead" or t == "Demon")
+    end
+    return self.creatureTypeUD
 end
 
 -- ============================================================
@@ -1080,10 +1096,19 @@ function M:Rotate(cfg)
     end
     -- 2b. Consecration leads AoE: when toggled on (checkbox or /sbr aoe), cast it
     -- on cooldown right after the strike so it is a primary AoE source rather
-    -- than a leftover filler. Held during mana recovery. Ground-targeted, but a
-    -- plain cast drops it at your feet on the usual SuperWoW/Nampower setup.
-    -- (damage/tank mode only)
-    if not cfg.healMode and cfg.spells.consecration and not self.manaMgmtActive
+    -- than a leftover filler. Ground-targeted, but a plain cast drops it at your
+    -- feet on the usual SuperWoW/Nampower setup. (damage/tank mode only)
+    --
+    -- Held during mana recovery UNLESS consecInMana is set. That opt-out exists
+    -- because the recovery flag is a latching hysteresis: it switches on below
+    -- manaLow and only off again at manaHigh, so with a wide band (a tank on
+    -- 60/90, say) it can stay on for an entire fight - mana sitting comfortably
+    -- in between, yet Consecration silently suppressed the whole time. The flag
+    -- is not surfaced anywhere, so that reads as "it is off cooldown and simply
+    -- not being cast". For a tank the AoE threat usually matters more than the
+    -- mana it saves, hence the switch.
+    if not cfg.healMode and cfg.spells.consecration
+        and (not self.manaMgmtActive or cfg.consecInMana)
         and self:KnowsSpell("Consecration") and self:IsReady("Consecration") then
         if self:Cast("Consecration") then return end
     end

--- a/classes/Class_Paladin_UI.lua
+++ b/classes/Class_Paladin_UI.lua
@@ -64,6 +64,7 @@ function M:BuildBody(ui, parent)
     self.spellCB.hammerOfWrath = L:Row{ key = "hammerOfWrath", label = "Hammer of Wrath", spell = "Hammer of Wrath", onToggle = sset("hammerOfWrath") }
     self.spellCB.repentance = L:Row{ key = "repentance", label = "Repentance", spell = "Repentance", onToggle = sset("repentance") }
     self.spellCB.consecration = L:Row{ key = "consecration", label = "Consecration", spell = "Consecration", onToggle = sset("consecration") }
+    self.consecManaRow = L:Row{ key = "consecInMana", label = "Consecration also in mana recovery", onToggle = set("consecInMana") }
     self.spellCB.exorcism = L:Row{ key = "exorcism", label = "Exorcism", spell = "Exorcism", onToggle = sset("exorcism") }
     self.twistRow = L:Row{ key = "sealTwist", label = "Seal twisting", onToggle = set("sealTwist") }
 
@@ -105,7 +106,8 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.spellCB.holyShield.cb,     "Holy Shield",     "Cast right after the strike, before seals.", "Fires whenever its own cooldown is ready.")
     ui:Tip(self.spellCB.hammerOfWrath.cb,  "Hammer of Wrath", "Execute, used only at or below 20 percent target HP.")
     ui:Tip(self.spellCB.repentance.cb,     "Repentance",      "Cast on cooldown as a damage proc on Turtle.")
-    ui:Tip(self.spellCB.consecration.cb,   "Consecration (AoE)", "AoE filler, cast on cooldown. Manual toggle (also /sbr aoe), since 1.12 cannot count nearby enemies.", "Held during mana recovery.")
+    ui:Tip(self.spellCB.consecration.cb,   "Consecration (AoE)", "AoE filler, cast on cooldown. Manual toggle (also /sbr aoe), since 1.12 cannot count nearby enemies.", "Held during mana recovery unless the option below is on.")
+    ui:Tip(self.consecManaRow.cb, "Consecration also in mana recovery", "Keeps casting Consecration even while mana recovery is running, instead of holding it until mana is back up.", "Worth knowing: mana recovery LATCHES. It switches on below the 'Switch below' value and only off again at 'Back above', so with a wide band (60/90 on a tank, say) it can stay on for a whole fight with mana sitting comfortably in between - and Consecration stays silently suppressed the entire time. If yours seems off cooldown but never fires, this is why. For a tank the AoE threat usually beats the mana saved.")
     ui:Tip(self.spellCB.exorcism.cb,       "Exorcism",        "Strong nuke, used on cooldown but only against Undead and Demon targets.", "Held during mana recovery.")
     ui:Tip(self.spellCB.holyStrike.cb, "Holy Strike", "Shares the 6s strike cooldown with Crusader Strike.", "With Vengeful Strikes it grants Holy Might. Even untalented it returns mana and heals the group.")
     ui:Tip(self.spellCB.crusaderStrike.cb, "Crusader Strike", "Shares the 6s strike cooldown with Holy Strike.", "Builds Zeal. Tank: with Righteous Strikes it also loads the block buff Zealous Defense.")
@@ -153,6 +155,14 @@ function M:RefreshBody(ui, buf)
     setCB("holyStrike"); setCB("crusaderStrike")
     setCB("holyShield"); setCB("hammerOfWrath"); setCB("repentance")
     setCB("consecration"); setCB("exorcism")
+
+    -- The mana-recovery override only means anything while Consecration itself
+    -- is on, so it greys out with it.
+    ui:BindCheck(self.consecManaRow, buf.consecInMana)
+    if not buf.spells.consecration then
+        self.consecManaRow.cb:Disable()
+        ui:Color(self.consecManaRow.label, ui.COL.grey)
+    end
 
     -- Both-on strategy: only meaningful when BOTH strikes are enabled. With a
     -- single strike on it is used exclusively, so the box is greyed and its text


### PR DESCRIPTION
Two small Paladin changes, both found while investigating a live report that Consecration was "off cooldown but never cast". Tested in game.

## The mana-recovery hold latches, and that is invisible

Consecration and Exorcism are both suppressed while mana recovery is active. The hold itself is intended — but the flag driving it is a **latching hysteresis**:

```lua
if mp < cfg.manaLow  then self.manaMgmtActive = true  end   -- below manaLow  -> ON
if mp >= cfg.manaHigh then self.manaMgmtActive = false end   -- at manaHigh   -> OFF
```

Between the two thresholds nothing happens: the flag keeps whatever it had. With a wide band it can therefore stay on for an entire fight. The live profile that triggered this report is a prot paladin on **manaLow 60 / manaHigh 90** — a tank drops below 60% early and essentially never climbs back to 90% in combat, so the flag stayed latched and Consecration was suppressed the whole time.

Nothing surfaces the flag anywhere, so from the outside this reads as "the spell is available and the rotation just ignores it".

**New per-profile toggle: "Consecration also in mana recovery"** (default **off**, so nothing changes for anyone who does not set it). Exempts Consecration alone from the hold — for a tank the AoE threat usually outweighs the mana saved. **Exorcism deliberately keeps the old behaviour**; only Consecration was asked for.

The toggle greys out while Consecration itself is off, and its tooltip spells out the latching behaviour so the next person does not have to rediscover it from scratch.

Worth noting for whoever picks this up later: the same latch also gates Exorcism and forces Seal of Wisdom, so a too-high `manaHigh` has wider effects than just this one spell. Not changed here — the defaults (30/70) are sane, this was a user-set 60/90.

## Creature-type cache

`TargetIsUndeadOrDemon()` called `UnitCreatureType("target")` on **every press**, in the rotation's hot path. The creature type cannot change under a given target, so all but the first press against each mob was a wasted call.

Now resolved once per target, keyed by target id (GUID based, so same-named mobs are told apart). A target swap re-reads immediately rather than answering from a stale cache; with no target the key is `""` and the answer is correctly `false`.

## Notes

- `scripts/verify.py --all` green.
- No version bump, per the existing pattern of feature commits followed by a separate `Cut vX.Y.Z`.
- Independent of #30 — branches from `main`, touches only the two Paladin files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)