### PR TITLE
Paladin heal: optional health gate so Holy Light stops crowding out Flash of Light

### DIFF
--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -161,7 +161,7 @@ M.templates = {
         hpManage = false, hpLow = 30, hpHigh = 70,
         strikeStyle = "autodps",
         spells = { holyStrike = false, crusaderStrike = false, holyShield = false, hammerOfWrath = false, repentance = false },
-        healMode = true, healThreshold = 75, useHolyShock = true, holyShockPct = 50, healPower = 0,
+        healMode = true, healThreshold = 75, useHolyShock = true, holyShockPct = 50, holyLightPct = 0, healPower = 0,
         healWeaveManaFloor = 40, healReloadCS = true, healSplashHS = true,
         healManaSelf = true, healManaJudge = false,
     },
@@ -252,6 +252,12 @@ function M:NormalizeProfile(c)
     -- old tab bug, which could store the string "damage" (truthy) into healMode.
     c.healMode = (c.healMode == true)
     if c.healThreshold == nil then c.healThreshold = 75 end
+    -- Reserve Holy Light for targets below this health percent (0 = off, the
+    -- efficiency comparison in DoHeal decides on its own). Community request:
+    -- Flash of Light is the mana-efficient workhorse, so some players want the
+    -- big heal held back for people who are genuinely low rather than picked
+    -- whenever the raw deficit happens to be large.
+    if c.holyLightPct == nil then c.holyLightPct = 0 end
     if c.useHolyShock == nil then c.useHolyShock = true end
     if c.holyShockPct == nil then c.holyShockPct = 50 end
     -- Split the old single heal-weave toggle into two independent behaviours
@@ -886,6 +892,20 @@ function M:DoHeal(cfg)
     -- Flash of Light instead of flip-flopping to a slower cast for pennies.
     local fol, folRaw = self:PickRank("Flash of Light", folEff, self.FOL_MANA, folDeficit, mana)
     local hl,  hlRaw  = self:PickRank("Holy Light", hlEff, self.HL_MANA, hlDeficit, mana)
+
+    -- Optional hard reservation of Holy Light for targets that are actually
+    -- low (holyLightPct, 0 = off). The comparison below already prefers Flash
+    -- of Light on efficiency, but it decides from the SIZE OF THE DEFICIT, not
+    -- from how hurt the unit is - so a big-health tank missing a lot in
+    -- absolute terms can pull a Holy Light while still sitting at a
+    -- comfortable percentage. This gate expresses the other intent directly:
+    -- above the threshold, spam the cheap fast heal regardless of deficit.
+    -- Only ever applied when Flash of Light is actually castable, so the gate
+    -- can never leave the unit with no heal at all.
+    if hl and fol and (cfg.holyLightPct or 0) > 0 and pct > (cfg.holyLightPct / 100) then
+        hl = nil
+    end
+
     local folLanded = fol and (folRaw * hdb) or nil
     local hlLanded  = hl  and (hlRaw  * hdb) or nil
     local folCovers = folLanded and folLanded >= deficit

--- a/classes/Class_Paladin_UI.lua
+++ b/classes/Class_Paladin_UI.lua
@@ -89,6 +89,8 @@ function M:BuildBody(ui, parent)
         slider = { key = "healThreshold", min = 0, max = 100, step = 5, suffix = "%", onChange = set("healThreshold") } }
     self.holyShockRow = L:Row{ key = "useHolyShock", label = "Holy Shock emergencies", spell = "Holy Shock", onToggle = set("useHolyShock"),
         slider = { key = "holyShockPct", min = 0, max = 100, step = 5, suffix = "%", onChange = set("holyShockPct") } }
+    self.holyLightRow = L:Row{ label = "Holy Light only below",
+        slider = { key = "holyLightPct", min = 0, max = 100, step = 5, suffix = "%", onChange = set("holyLightPct") } }
     self.healReloadRow = L:Row{ key = "healReloadCS", label = "Reload Holy Shock (CS)", onToggle = set("healReloadCS") }
     self.healSplashRow = L:Row{ key = "healSplashHS", label = "Holy Strike filler", onToggle = set("healSplashHS"),
         slider = { key = "healWeaveManaFloor", min = 0, max = 90, step = 5, suffix = "%", onChange = set("healWeaveManaFloor") } }
@@ -123,6 +125,7 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.holyShockRow.cb, "Holy Shock emergencies", "Use the instant Holy Shock for an emergency or a hurt unit out of melee range.")
     ui:Tip(self.holyShockRow.cb, "Holy Shock emergencies", "In heal mode Holy Shock is used ONLY as an instant heal, never for damage.", "Fires for an emergency or a hurt unit out of melee range, below the health value on the right.")
     ui:Tip(self.holyShockRow.slider, "Holy Shock below", "Health under which Holy Shock is used as an instant emergency heal.", "Below this same line, Flash of Light is also kept over Holy Light even for a big deficit - faster beats fuller when it's this close. Also /sbr hsat <1-100>. +healing auto-reads from gear; override with /sbr healpower <n>.")
+    ui:Tip(self.holyLightRow.slider, "Holy Light only below", "Reserve Holy Light for targets under this health percent. Above it, Flash of Light is used no matter how big the deficit is. 0 switches the restriction off.", "Off by default, because the heal choice is already made on efficiency: the smallest rank of each that covers the deficit is compared by what actually lands, and Flash of Light wins ties unless Holy Light wastes at least 10% less. That decides from the SIZE of the deficit though, so a high-health tank missing a lot in absolute terms can pull a Holy Light while still at a comfortable percentage. Set this if you would rather spam the cheap fast heal until someone is genuinely low.")
     ui:Tip(self.healReloadRow.cb, "Reload Holy Shock (CS)", "When Holy Shock is on cooldown, use Crusader Strike to reset it (Blessed Strikes, auto-detected), keeping the emergency instant loaded.", "Uses a GCD, but never fires while anyone is below the Holy Shock line - the heal comes first. Not limited by the filler mana floor.")
     ui:Tip(self.healSplashRow.cb, "Holy Strike filler", "In downtime with nobody to heal, use Holy Strike so its splash tops the melee group.", "Uses a GCD, and only above the mana value on the right, so filler never starves a heal.")
     ui:Tip(self.healSplashRow.slider, "Filler mana floor", "Holy Strike filler only fires while your mana is above this.")
@@ -237,6 +240,12 @@ function M:RefreshBody(ui, buf)
     local hsKnown = self:KnowsSpell("Holy Shock")
     ui:BindCheck(self.holyShockRow, buf.useHolyShock and hsKnown, "Holy Shock")
     self.holyShockRow.slider:SetValue(buf.holyShockPct or 50); self.holyShockRow.slider.valText:SetText((buf.holyShockPct or 50) .. "%")
+    -- 0 means "no restriction" and must survive: an `or` fallback would turn a
+    -- deliberate 0 into whatever default sat on the right of it.
+    local hlp = buf.holyLightPct
+    if hlp == nil then hlp = 0 end
+    self.holyLightRow.slider:SetValue(hlp)
+    self.holyLightRow.slider.valText:SetText(hlp == 0 and "off" or (hlp .. "%"))
     -- The heal controls live in the heal-only "Healing" card, which the tab rail
     -- hides entirely on the Damage tab, so no mode gating is needed here.
     if not hsKnown then


### PR DESCRIPTION
Community report from a level-60 healing paladin: above the emergency line, the rotation essentially always casts Holy Light. Confirmed — and it is not a matter of preference. The efficiency comparison that was supposed to favour Flash of Light is effectively dead code.

## Why Flash of Light never wins

The comparison in `DoHeal` only runs in the branch where **both** heals cover the deficit:

```lua
if folCovers and hlCovers then
    if hlLanded <= folLanded * 0.9 then pick = hl else pick = fol end
elseif folCovers then pick = fol
elseif hlCovers then pick = hl      -- <- this is what actually fires
```

But the numbers make `folCovers` almost always false:

| | max base heal |
|---|---|
| Flash of Light (rank 7) | **428** |
| Holy Light (rank 9) | **1680** |

Healing does not even begin until a unit is 25% down (`healThreshold`, default 75). On a 2000 HP target that is already a 500 deficit; at 60 with 3500 HP it is 875. Both past 428 — so Flash of Light is disqualified *before* the efficiency check, and `elseif hlCovers` picks Holy Light by default.

The 10%-margin tie-breaker underneath it can therefore only fire on a target too lightly hurt to be healed in the first place. It has never done anything.

## The fix

New **`holyLightPct`** slider (default `0` = off): reserve Holy Light for units below a set health percent. Above it, Flash of Light is used regardless of how large the deficit is.

This deliberately **bypasses** the coverage logic rather than tuning it — the problem is that coverage gets to decide at all. Two guards:

- Only applied while Flash of Light is actually castable (`hl and fol and ...`), so the gate can never leave a unit with no heal.
- `0` is a meaningful value and must survive: the UI reads the field without an `or` fallback, which would silently turn a deliberate 0 into a default, and displays it as "off".

Left **off by default** pending in-game feedback. 75–80 is the value suggested to the reporter.

## Notes

- `scripts/verify.py --all` green.
- Independent of #31 despite both touching the Paladin files — that one is the Consecration mana-hold and the creature-type cache, in different functions.
- Not verified by me in play: my own paladin is level 48 with almost no spellcrit or intellect gear, so the endgame behaviour this addresses is outside what I can observe. Reviewed against the code and the rank tables instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)