### PR TITLE
Paladin heal: apply the sub-level-20 +healing penalty to downranked Holy Light

### DIFF
--- a/classes/Class_Paladin.lua
+++ b/classes/Class_Paladin.lua
@@ -82,6 +82,21 @@ M.HL_MANA  = { 35, 60, 110, 190, 275, 365, 465, 580, 660 }
 M.HS_HEAL  = { 315, 360, 500, 655 }
 M.HS_MANA  = { 225, 335, 410, 485 }
 
+-- +Healing penalty factor for spells learnt BEFORE level 20: such a rank only
+-- receives (1 - (20 - levelLearnt) * 0.0375) of the gear bonus, while its base
+-- heal is unaffected. This is what stops downranking from scaling for free with
+-- +healing, and it only bites harder the better the gear gets - at +900 healing
+-- an unpenalised Holy Light rank 1 looks like a ~690 heal when it actually lands
+-- ~230, so the rank picker would happily choose it and badly underheal.
+--
+-- Verified against QuickHeal (QuickHealPaladin.lua), which documents the same
+-- formula in a comment and applies it identically; its priest module derives a
+-- different set of factors from the same rule, which confirms the reading.
+-- Only Holy Light is affected: ranks 1/2/3 are learnt at level 1/6/14. Flash of
+-- Light starts at level 20 and Holy Shock at 40, so both come out at a factor of
+-- 1 and need no table.
+M.HL_PEN = { 0.2875, 0.475, 0.775 }   -- ranks 1-3; nil (= 1) from rank 4 up
+
 -- Auto-read the gear +healing bonus by scanning equipped-item tooltips. Cached,
 -- refreshed when equipment changes. A manual healPower above zero overrides it.
 local healScanTip = CreateFrame("GameTooltip", "Aegis_SBR_HealScan", nil, "GameTooltipTemplate")
@@ -733,10 +748,15 @@ function M:HealMods()
 end
 
 -- Effective heal per rank: base + healing-coefficient * bonus, then talents.
-function M:EffHeals(baseHeals, coeff, mods, healPower)
+-- `pen` is the optional per-rank +healing penalty for ranks learnt below level
+-- 20 (see HL_PEN). It scales ONLY the gear-bonus part, never the base heal,
+-- which is what makes a downranked heal stop keeping pace with gear.
+function M:EffHeals(baseHeals, coeff, mods, healPower, pen)
     local t = {}
     for r = 1, table.getn(baseHeals) do
-        t[r] = (baseHeals[r] + coeff * (healPower or 0)) * mods
+        local p = 1
+        if pen and pen[r] then p = pen[r] end
+        t[r] = (baseHeals[r] + coeff * (healPower or 0) * p) * mods
     end
     return t
 end
@@ -825,7 +845,7 @@ function M:DoHeal(cfg)
     local hlMod, dfMod = self:HealMods()
     local C15, C25 = 1.5 / 3.5, 2.5 / 3.5
     local folEff = self:EffHeals(self.FOL_HEAL, C15, hlMod, hp)
-    local hlEff  = self:EffHeals(self.HL_HEAL,  C25, hlMod, hp)
+    local hlEff  = self:EffHeals(self.HL_HEAL,  C25, hlMod, hp, self.HL_PEN)
     local hsEff  = self:EffHeals(self.HS_HEAL,  C15, hlMod * dfMod, hp)
 
     -- Healing-reduction debuffs (Mortal Strike and the like) inflate the


### PR DESCRIPTION
Rank selection overestimated downranked Holy Light, and the error grows with gear — so it is worst exactly where paladins spend their endgame.

## The bug

Spell ranks learnt below level 20 only receive `1 - (20 - levelLearnt) * 0.0375` of the gear +healing bonus. The base heal is unaffected. This is what stops downranking from scaling for free with gear.

`EffHeals` applied the full coefficient to every rank:

```lua
t[r] = (baseHeals[r] + coeff * healPower) * mods
```

At +900 healing, which is unremarkable for a level-60 paladin:

| | estimated | actual | over by |
|---|---|---|---|
| Holy Light R1 | 693 | **235** | 3.0× |
| Holy Light R2 | 726 | **388** | 1.9× |
| Holy Light R3 | 816 | **671** | 1.2× |
| Holy Light R4 | 976 | 976 | — |

With no +healing nothing changes at all; the penalty only ever scales the bonus portion.

## Why it matters twice

**Rank selection.** `PickRank` takes the *smallest* rank whose estimate covers the deficit, so an inflated low rank wins outright. A 600 deficit picked Holy Light rank 1 expecting 693 and landed ~235 — a severe underheal that looks like the addon simply healing too little.

**Spell selection.** The same inflated number becomes `hlLanded` in the Flash of Light / Holy Light comparison, making `hlCovers` true more often than it should. So this partly drives the community report that Holy Light crowds out Flash of Light above the emergency line — it is not only the coverage rule.

## Scope

Only Holy Light needs a table: its ranks 1/2/3 are learnt at level 1/6/14. Flash of Light starts at 20 and Holy Shock at 40, so both come out at a factor of 1 and are left alone.

```lua
M.HL_PEN = { 0.2875, 0.475, 0.775 }   -- ranks 1-3; nil (= 1) from rank 4 up
```

`EffHeals` takes an optional `pen` argument that scales only the bonus term.

## Verified, not derived

Checked against QuickHeal rather than reasoned out: `QuickHealPaladin.lua` states the formula in a comment —

```lua
-- +Healing-PenaltyFactor = (1-((20-LevelLearnt)*0.0375)) for all spells learnt before level 20
local PF1 = 0.2875;  local PF6 = 0.475;  local PF14 = 0.775;
```

— and applies the same three factors to the same ranks. Its priest module derives a different set (`PF1/PF4/PF10/PF18`) from the same rule, which confirms the reading.

## Note

This supersedes #32, which I have closed. That PR added a health-percentage gate for Holy Light in response to the same community report, but in the opposite polarity to how QuickHeal (and this addon's own emergency branch) handle it — and it was treating a symptom this fix addresses at the source. Worth re-measuring in game before deciding whether an extra slider is still wanted.

`scripts/verify.py --all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)