### PR TITLE
Warlock: Drain Soul as a filler and as the Dark Harvest gap filler

### DIFF
--- a/classes/Class_Warlock.lua
+++ b/classes/Class_Warlock.lua
@@ -26,10 +26,13 @@
 --        Shard and regen mana (the leveling finisher). Optionally capped by
 --        keepShards/shardTarget so it stops once enough shards are banked.
 --  * When nothing above applies, fall back to the filler: the wand, Shadow
---    Bolt, Drain Life, or Dark Harvest. The wand filler degrades to Shadow
---    Bolt when no wand is equipped, so a level 1 warlock (Shadow Bolt only)
---    still nukes. Dark Harvest wands (or Shadow Bolts) the gap between its
---    own cooldowns instead of leaving the rotation idle.
+--    Bolt, Drain Life, Drain Soul, or Dark Harvest. The wand filler degrades
+--    to Shadow Bolt when no wand is equipped, so a level 1 warlock (Shadow
+--    Bolt only) still nukes. Drain Soul is there for the low-level warlock
+--    with no wand yet; being a channel it stands down for a press whenever a
+--    DoT would lapse while it runs. Dark Harvest fills the gap between its own cooldowns with
+--    a configurable choice (dhGapFiller: wand, Shadow Bolt, Drain Life or
+--    Drain Soul) instead of leaving the rotation idle.
 --  * Optional Life Tap when mana is low and health is high.
 --  * Nightfall reaction: a free instant Shadow Bolt the moment Shadow Trance
 --    procs. This auto-enables when the Nightfall talent is detected (the one
@@ -194,7 +197,26 @@ local RAPID_DETERIORATION_PCT_PER_RANK = 3
 M.dotNumTicks = { ["Corruption"] = 6, ["Curse of Agony"] = 12, ["Siphon Life"] = 10 }
 
 -- Filler universe
-M.FILLERS = { "Shoot", "Shadow Bolt", "Drain Life", "Dark Harvest" }
+M.FILLERS = { "Shoot", "Shadow Bolt", "Drain Life", "Drain Soul", "Dark Harvest" }
+
+-- What fills the gap while Dark Harvest is on cooldown. Only consulted when
+-- Dark Harvest is the chosen filler; the wand stays the default because it is
+-- free. Drain Soul is here by user request (a player who does not want to wand
+-- at all) - note it is a CHANNEL, which is why DS_CHANNEL_BASE below exists.
+M.GAP_FILLERS = { "Shoot", "Shadow Bolt", "Drain Life", "Drain Soul" }
+
+-- Drain Soul's base channel length on Turtle. NOT the vanilla 15s: confirmed
+-- in-game at 5.64s with Rapid Deterioration 2/2, and 6 * 0.94 = 5.64 exactly,
+-- so the base is 6 and the talent scales it - the same relationship already
+-- established for Dark Harvest (8 -> 7.52 at the same rank). Use
+-- DSChannelLength() rather than this raw base.
+--
+-- Only used to decide whether STARTING a channel is safe, never to track a
+-- running one (the SPELLCAST_CHANNEL_* watcher does that). Two things must not
+-- happen while it runs, because the channel guard stops the rotation acting at
+-- all: a DoT lapsing unrefreshed, and Dark Harvest coming off cooldown with
+-- nobody there to press it.
+local DS_CHANNEL_BASE = 6
 
 M.templates = {
     starter = {  -- usable from level 1: the filler is the wand, which falls
@@ -263,6 +285,9 @@ function M:NormalizeProfile(c)
     if c.lifeTapMana == nil then c.lifeTapMana = 20 end
     if c.lifeTapHpMin == nil then c.lifeTapHpMin = 40 end
     if c.wandManaFloor == nil then c.wandManaFloor = 15 end
+    -- What fills the gap while Dark Harvest is on cooldown (Dark Harvest filler
+    -- only). Defaults to the wand, which is what the gap used to be hardcoded to.
+    if c.dhGapFiller == nil then c.dhGapFiller = "Shoot" end
     if c.nightfall == nil then c.nightfall = false end
     if c.drainLifeSustain == nil then c.drainLifeSustain = false end
     if c.drainLifeHp == nil then c.drainLifeHp = 35 end
@@ -418,6 +443,12 @@ function M:DHChannelLength()
     return DH_CHANNEL_BASE * (1 - self:RapidDeteriorationPct() / 100)
 end
 
+-- Drain Soul's channel length, scaled by Rapid Deterioration exactly like Dark
+-- Harvest's (see DS_CHANNEL_BASE for the in-game confirmation).
+function M:DSChannelLength()
+    return DS_CHANNEL_BASE * (1 - self:RapidDeteriorationPct() / 100)
+end
+
 -- Minimum DoT time remaining needed to survive a full Dark Harvest channel at
 -- its 30%-accelerated tick rate (see DH_TICK_BOOST above).
 function M:DHMinDotRemain()
@@ -494,21 +525,39 @@ function M:DotRemaining(spellName)
     return remain
 end
 
--- True when any enabled, tracked DoT is due to fall off within
--- WAND_STOP_BEFORE_DOT seconds (see there). A DoT with no confident estimate
--- (DotRemaining returns nil) never counts, matching the "unknown is not
--- urgent" stance used for the Dark Harvest pre-check.
-function M:DotExpiringSoon(order)
+-- True when any enabled, tracked DoT is due to fall off within `within`
+-- seconds. A DoT with no confident estimate (DotRemaining returns nil) never
+-- counts, matching the "unknown is not urgent" stance used for the Dark
+-- Harvest pre-check.
+function M:DotExpiringSoonBy(order, within)
     for i = 1, table.getn(order) do
         local sp = order[i][1]
         if self:KnowsSpell(sp) then
             local remain = self:DotRemaining(sp)
-            if remain and remain <= WAND_STOP_BEFORE_DOT then
+            if remain and remain <= within then
                 return true
             end
         end
     end
     return false
+end
+
+-- The wand's own horizon (see WAND_STOP_BEFORE_DOT).
+function M:DotExpiringSoon(order)
+    return self:DotExpiringSoonBy(order, WAND_STOP_BEFORE_DOT)
+end
+
+-- Seconds left on a spell's OWN cooldown, ignoring the global cooldown; 0 when
+-- it is ready. Needed to tell whether a long channel would still be running
+-- when Dark Harvest comes back up.
+function M:OwnCDLeft(name)
+    local slot = self:FindSpellSlot(name)
+    if not slot then return 0 end
+    local start, dur = GetSpellCooldown(slot, BOOKTYPE_SPELL)
+    if start == 0 or dur <= 1.55 then return 0 end
+    local left = start + dur - GetTime()
+    if left < 0 then left = 0 end
+    return left
 end
 
 -- Throttle memory per DoT, keyed by target GUID. Only stamped once
@@ -841,6 +890,34 @@ function M:Rotate(cfg)
             self:Queue("Dark Harvest")
             return
         end
+        -- Dark Harvest is on cooldown: fill the gap with the configured choice.
+        local gap = cfg.dhGapFiller or "Shoot"
+
+        -- Drain Soul is a channel, and the guard at the top of Rotate stops the
+        -- rotation acting for its whole length. Starting one is therefore only
+        -- safe when nothing needs attention during it: no enabled DoT may lapse,
+        -- and Dark Harvest must not come off cooldown mid-channel and sit there
+        -- unpressed. Both fall back to the wand rather than blocking the press.
+        if gap == "Drain Soul" and self:KnowsSpell("Drain Soul") then
+            local dsLen = self:DSChannelLength()
+            local dhLeft = self:OwnCDLeft("Dark Harvest")
+            local dotSafe = not self:DotExpiringSoonBy(order, dsLen)
+            if dotSafe and dhLeft >= dsLen then
+                self:Queue("Drain Soul")
+                return
+            end
+            gap = "Shoot"   -- not safe right now, ride the wand until it is
+        end
+
+        if gap == "Drain Life" and self:KnowsSpell("Drain Life") then
+            self:Queue("Drain Life")
+            return
+        end
+        if gap == "Shadow Bolt" and self:KnowsSpell("Shadow Bolt") then
+            self:Queue("Shadow Bolt")
+            return
+        end
+
         if self:HasWand() then
             if self:DotExpiringSoon(order) then
                 if self:Wanding() then CastSpellByName("Shoot") end -- toggles the repeat off
@@ -867,6 +944,22 @@ function M:Rotate(cfg)
         -- spammable wand, only start it if it is not already auto repeating
         if self:Wanding() then return end
         CastSpellByName("Shoot")
+    elseif filler == "Drain Soul" then
+        -- Same channel caution as the Dark Harvest gap filler, minus the
+        -- cooldown half: there is no Dark Harvest to be held up here, only the
+        -- DoTs, which cannot be refreshed while the channel guard is holding
+        -- the rotation. If one would lapse during it, fall through to the wand
+        -- (or Shadow Bolt without one) for this press instead.
+        if not self:DotExpiringSoonBy(order, self:DSChannelLength()) then
+            self:Queue("Drain Soul")
+            return
+        end
+        if self:HasWand() then
+            if self:Wanding() then return end
+            CastSpellByName("Shoot")
+        elseif self:KnowsSpell("Shadow Bolt") then
+            self:Queue("Shadow Bolt")
+        end
     elseif filler then
         self:Queue(filler)
     end

--- a/classes/Class_Warlock_UI.lua
+++ b/classes/Class_Warlock_UI.lua
@@ -26,6 +26,7 @@ function M:BuildBody(ui, parent)
 
     L:Header("Filler and pet")
     self.fillerDD = L:Dropdown("filler", "Filler", 200, set("filler"))
+    self.gapDD = L:Dropdown("dhGapFiller", "Between channels", 200, set("dhGapFiller"))
     self.petRow = L:Row{ key = "petAttack", label = "Send pet to attack", onToggle = set("petAttack") }
     self.petMeleeRow = L:Row{ key = "petMeleeOnly", label = "Pet melee only", onToggle = set("petMeleeOnly") }
     self.nightfallRow = L:Row{ key = "nightfall", label = "Shadow Bolt on Shadow Trance", spell = "Shadow Bolt", onToggle = set("nightfall") }
@@ -65,7 +66,8 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.siphRow.cb, "Siphon Life", "Shadow damage over time that also heals you.")
     ui:Tip(self.curseDD, "Curse", "One curse per target. Curse of Agony has exact upkeep,", "others are reapplied on a timer for now.")
     ui:Tip(self.coaRow.cb, "Keep Curse of Agony up too", "Malediction lets Curse of Agony run beside your main curse but it expires sooner.", "When on, only Curse of Agony is recast as it falls off. Not used with Curse of Doom or when it already is the main curse.")
-    ui:Tip(self.fillerDD, "Filler", "Used when every enabled DoT is up.", "Wand conserves mana, Shadow Bolt and Drain Life spend it. Dark Harvest is channeled on its cooldown and wands (or Shadow Bolts) the gap in between.")
+    ui:Tip(self.fillerDD, "Filler", "Used when every enabled DoT is up.", "Wand conserves mana, Shadow Bolt and Drain Life spend it. Drain Soul is the option for a low-level warlock with no wand yet - it is a channel, so it is skipped for a press whenever a DoT would lapse while it runs. Dark Harvest is channeled on its cooldown and fills the gap in between with the choice below.")
+    ui:Tip(self.gapDD, "Between channels", "What to use while Dark Harvest is on cooldown. Only applies when Dark Harvest is your filler.", "Drain Soul is a channel, so it is only started when nothing needs you during it: no DoT about to lapse, and Dark Harvest not coming off cooldown mid-channel. When either is true the wand covers the gap instead, so the channel can never cost you a DoT or delay the next Dark Harvest.")
     ui:Tip(self.petRow.cb, "Pet attack", "Send the active pet onto your target.")
     ui:Tip(self.petMeleeRow.cb, "Pet only in melee range", "Send the pet only when the target is within melee range,", "so an accidentally targeted far enemy does not pull the pet away.")
     ui:Tip(self.nightfallRow.cb, "Shadow Bolt on Shadow Trance", "When the Nightfall proc lights up, fire the free instant Shadow Bolt.", "Auto-enabled when the Nightfall talent is detected; this toggle forces it on otherwise. Only used when the filler is not already Shadow Bolt.")
@@ -107,6 +109,7 @@ function M:RefreshBody(ui, buf)
     local fo = { { label = "Wand (Shoot)", value = "Shoot" } }
     if self:KnowsSpell("Shadow Bolt") then table.insert(fo, { label = "Shadow Bolt", value = "Shadow Bolt" }) end
     if self:KnowsSpell("Drain Life")  then table.insert(fo, { label = "Drain Life",  value = "Drain Life" })  end
+    if self:KnowsSpell("Drain Soul")  then table.insert(fo, { label = "Drain Soul",  value = "Drain Soul" })  end
     if self:KnowsSpell("Dark Harvest") then table.insert(fo, { label = "Dark Harvest", value = "Dark Harvest" }) end
     local fcur = buf.filler or "Shoot"
     local fshown, fc
@@ -114,6 +117,20 @@ function M:RefreshBody(ui, buf)
     elseif self:KnowsSpell(fcur) then fshown, fc = fcur, ui.COL.white
     else fshown, fc = fcur .. " (not learned)", ui.COL.red end
     ui:SetDropdown(self.fillerDD, fo, fcur, fshown, fc)
+
+    -- Gap filler: only meaningful while Dark Harvest is the chosen filler, so
+    -- it is greyed out otherwise rather than silently doing nothing.
+    local go = { { label = "Wand (Shoot)", value = "Shoot" } }
+    if self:KnowsSpell("Shadow Bolt") then table.insert(go, { label = "Shadow Bolt", value = "Shadow Bolt" }) end
+    if self:KnowsSpell("Drain Life")  then table.insert(go, { label = "Drain Life",  value = "Drain Life" })  end
+    if self:KnowsSpell("Drain Soul")  then table.insert(go, { label = "Drain Soul",  value = "Drain Soul" })  end
+    local gcur = buf.dhGapFiller or "Shoot"
+    local gshown, gc
+    if gcur == "Shoot" then gshown, gc = "Wand (Shoot)", ui.COL.white
+    elseif self:KnowsSpell(gcur) then gshown, gc = gcur, ui.COL.white
+    else gshown, gc = gcur .. " (not learned)", ui.COL.red end
+    if fcur ~= "Dark Harvest" then gshown, gc = gshown .. " (Dark Harvest only)", ui.COL.grey end
+    ui:SetDropdown(self.gapDD, go, gcur, gshown, gc)
 
     ui:BindCheck(self.immoRow, buf.useImmolate)
     ui:BindCheck(self.corrRow, buf.useCorruption)
@@ -152,10 +169,24 @@ function M:RefreshBody(ui, buf)
     self.dsoulRow.slider:SetValue(buf.drainSoulHp or 0);  self.dsoulRow.slider.valText:SetText((buf.drainSoulHp or 0) .. "%")
     self.shardRow.slider:SetValue(buf.shardTarget or 1);  self.shardRow.slider.valText:SetText(tostring(buf.shardTarget or 1))
     ui:SliderEnable(self.sburnRow.slider, self:KnowsSpell("Shadowburn") and buf.useShadowburn)
-    ui:SliderEnable(self.dsoulRow.slider, self:KnowsSpell("Drain Soul") and buf.useDrainSoul)
+
+    -- With Drain Soul chosen as the filler it already runs above the execute
+    -- threshold as well, so the execute finisher has nothing left to add - the
+    -- setting would sit there looking meaningful while changing nothing. Greyed
+    -- out and relabelled rather than silently ignored.
+    -- KnowsSpell-gated so an unlearned Drain Soul keeps BindCheck's own
+    -- "(not learned)" label instead of being relabelled over it.
+    local dsIsFiller = (buf.filler == "Drain Soul") and self:KnowsSpell("Drain Soul")
+    if dsIsFiller then
+        self.dsoulRow.cb:Disable()
+        self.dsoulRow.label:SetText(self.dsoulRow.baseText .. " - already the filler")
+        ui:Color(self.dsoulRow.label, ui.COL.grey)
+    end
+    ui:SliderEnable(self.dsoulRow.slider, self:KnowsSpell("Drain Soul") and buf.useDrainSoul and not dsIsFiller)
+
     -- Keeping shards is a refinement of the Drain Soul finisher, so grey it
-    -- out whenever that finisher itself is off or unlearned.
-    local dsoulOn = self:KnowsSpell("Drain Soul") and buf.useDrainSoul
+    -- out whenever that finisher itself is off, unlearned, or superseded above.
+    local dsoulOn = self:KnowsSpell("Drain Soul") and buf.useDrainSoul and not dsIsFiller
     if not dsoulOn then
         self.shardRow.cb:Disable()
         ui:Color(self.shardRow.label, ui.COL.grey)

--- a/docs/turtle-mechanics.md
+++ b/docs/turtle-mechanics.md
@@ -91,6 +91,11 @@ forum.turtlecraft.gg theorycraft threads, r/turtlewow, community class guides.
 ## Warlock
 - **Dark Harvest** (Affliction capstone). **Nightfall** procs from Corruption, Dark Harvest,
   and drains. **Malediction** lets Curse of Agony coexist with another curse.
+- **Channel lengths are NOT the vanilla ones, and Rapid Deterioration scales them.**
+  Dark Harvest is 8s base, Drain Soul **6s** base (vanilla: 15s). The talent shortens the
+  channel by the same 3%/rank it takes off Corruption / Curse of Agony / Siphon Life, so at
+  2/2 they read **7.52s** and **5.64s** — both confirmed against in-game tooltips. Any code
+  reasoning about "can I fit this channel in" must scale by the rank actually taken.
 
 ## Druid
 - **Powershift Shred** dominant for Feral DPS (bleeds weaker, can't crit). **Savage Bite**


### PR DESCRIPTION
Two player requests, both amounting to "don't force me onto the wand".

## Drain Soul in the main filler dropdown

It was never a filler in the tracked history — but `docs/rotations.md` lists it as one in **both** the Affliction and levelling reference rotations. Code and research had drifted apart since shard farming was folded into the execute finisher, and this closes that gap.

## New "Between channels" dropdown

Picks what fills the gap while Dark Harvest is on cooldown: wand, Shadow Bolt, Drain Life or Drain Soul. That gap was previously hardcoded to the wand (falling back to Shadow Bolt). Only meaningful with Dark Harvest as the filler, so it greys out and says `(Dark Harvest only)` otherwise.

## The channel guard is the actual work

The guard at the top of `Rotate` stops the rotation acting **at all** while a channel runs. Starting a Drain Soul is therefore only safe when nothing needs attention during it:

- **no enabled DoT may lapse** — otherwise Corruption quietly falls off with the rotation unable to react
- **Dark Harvest must not come off cooldown mid-channel** (gap-filler case only) — otherwise your strongest spell sits ready with nobody able to press it

If either fails it stands down for that press and rides the wand instead, so the channel can never cost a DoT or delay the next Dark Harvest.

`DotExpiringSoon` gained a variant taking the horizon as an argument; `OwnCDLeft` is new.

## Channel length is computed, not assumed

Turtle's Drain Soul is **6s base, not the vanilla 15s**. Confirmed in game at **5.64s** with Rapid Deterioration 2/2 — and `6 × 0.94 = 5.64` exactly, the same relationship already established for Dark Harvest (`8 → 7.52` at that rank). So it is derived via `DSChannelLength()`, scaling with the rank actually taken, mirroring `DHChannelLength()`.

This mattered: an earlier hardcoded 15 would have stopped the gap filler ever starting, because a 15s channel never fits inside the ~22s Dark Harvest gap. Recorded in `docs/turtle-mechanics.md` — the third vanilla value this week that turned out wrong for Turtle.

## Execute row greys out when Drain Soul is the filler

With Drain Soul as filler it already runs above the execute threshold as well, so the execute finisher has nothing left to add. That row is greyed and relabelled `- already the filler` rather than sitting there looking meaningful. The **stored setting is kept**, so switching the filler back restores the previous configuration. Gated on `KnowsSpell` so an unlearned Drain Soul keeps its own `(not learned)` label instead of being relabelled over.

## Notes

- `scripts/verify.py --all` green.
- Defaults unchanged: the gap filler defaults to `Shoot`, which is exactly what the gap was hardcoded to before, so no existing profile changes behaviour.
- Not yet verified in play — the requester wanted it for a no-wand playstyle, which is the case to try first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)