### PR TITLE
Changelog + version for v1.1.3, and two approved Warrior fixes (v1.1.4)

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -16,7 +16,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.1.3",
+    ver = "1.1.4",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.1.3
+## Version: 1.1.4
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.1.4 — Warrior: Charge no longer lost to Bloodrage, Rend stops on bleed-immune targets
+
+**Two Warrior fixes, both reported from play and both approved before the change.** No
+priority ORDER was altered: one removes a *disqualification*, the other adds a *gate*.
+
+- **Charge is no longer killed by Bloodrage on the pull.** Bloodrage sits in the off-GCD
+  layer and fired on any pull press where rage was under the threshold — and out of combat
+  rage is always 0, so it fired on *every* pull press. That didn't merely go first: Bloodrage
+  puts you in combat, and the Charge gate is `not inCombat`, so from the next press onward
+  Charge was unreachable for the whole pull. The symptom in game was Charge never firing even
+  at perfect range. (The two also both issued a `CastSpellByName` in the same frame, which is
+  unreliable on 1.12 — a later call can override an earlier one.) Bloodrage now holds while a
+  Charge opener is pending, which costs nothing: **Charge generates the rage itself**, and
+  Bloodrage is still available the moment you land. The hold deliberately persists while
+  stance-dancing to Battle, since the opener is still pending during the dance.
+- **Rend is no longer spammed at targets that cannot bleed.** Mechanical and Elemental mobs
+  are immune, so the debuff never lands, so the "not already on the target" test stayed true
+  and Rend was re-attempted on **every press** — a wasted GCD and 10 rage each time, for the
+  whole fight. Rend now checks creature type first, cached per target id on the pattern the
+  Paladin already uses for Exorcism (one API call per target, not per press; a target swap
+  re-reads immediately rather than answering stale). An **unknown** creature type still allows
+  the cast — `UnitCreatureType` returns nil for some units, and failing open is only today's
+  behaviour, where failing closed would silently disable Rend against ordinary mobs.
+  *Localisation note:* the check compares English strings, so on a non-enUS client it
+  degrades to "never immune" — the safe direction, but it means the fix is enUS-only for now.
+
+*Still open in the Warrior module:* an Overpower report (the proc being passed over for Slam
+and Heroic Strike) is **not** addressed here. Overpower already sits above the strikes and
+Slam in the priority list, so the cause is something else — most likely the Battle Stance
+gate with stance-dancing off, or the proc window being cleared before a failed cast. Awaiting
+a `/sbr log` capture to tell those apart rather than guessing at a hand-tuned list.
+
+---
+
 ## v1.1.3 — Rogue tuning + press log, Paladin Consecration & heal-rank fixes, Warlock fillers
 
 **First code release after the v1.1.0 cut.** Four merges land here: Rogue tuning with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ execute finisher and a Paladin double-heal fix (v0.16.0), and an opt-in Warrior 
 Strike (v0.16.2, Arms talent, off by default). Off-hand imbue, poison auto-apply beyond
 the Quick Bar, and Shaman totem-destruction detection remain open Phase 2 items.
 v1.1.0 was a docs-only cut (README overhaul + a `docs/research-classicapi.md` deep-dive);
-no rotation/engine code changed in it. **v1.1.3 is the current release** — the first code
+no rotation/engine code changed in it. v1.1.3 was the first code
 cut after it, folding in four merges: Rogue buff-renew slider + opt-in Cold Blood and the
 `/sbr log` press log (#30), a Paladin Consecration mana-recovery opt-out + creature-type
 cache (#31), the sub-level-20 +healing penalty applied to downranked Holy Light (#33), and
@@ -69,6 +69,16 @@ the Warlock filler upgrades — Drain Soul as a main filler and a configurable D
 gap filler (#34). No priority ORDER changed in any of them. PR **#32** (a `holyLightPct`
 health gate for the same Flash of Light problem) was **closed unmerged**, superseded by #33
 — don't treat it as shipped; whether a slider is wanted, and which way it points, is open.
+**v1.1.4 is the current release** — two approved Warrior fixes from play reports: Bloodrage
+now holds while a Charge opener is pending (it flags combat, and Charge's gate is
+`not inCombat`, so it was *disqualifying* Charge for the whole pull, not merely going
+first), and Rend is gated on a cached `TargetIsBleedImmune()` so it stops re-firing every
+press at Mechanical/Elemental mobs. No priority ORDER changed. **Open Warrior item:** a
+report that Overpower is passed over for Slam/Heroic Strike — it already sits ABOVE both in
+the list, so the cause is elsewhere (likeliest: the Battle Stance gate at
+`Class_Warrior.lua:422` when `cfg.stanceDance` is off, or `overpowerExpiry` being zeroed at
+`:423` *before* a cast that then fails — Revenge has the same bug at `:407`). Awaiting a
+`/sbr log` capture; the Warrior trace already carries an `op=Y/N` field for exactly this.
 
 ## Tech Stack / Hard Constraints (WHAT — read carefully, these bite)
 - **Language: Lua 5.0** (Turtle 1.12 client). Non-negotiable:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.1.3)
+# Aegis: Single Button Rotation (v1.1.4)
 
 **One button. Your whole rotation.**
 

--- a/classes/Class_Warrior.lua
+++ b/classes/Class_Warrior.lua
@@ -304,6 +304,32 @@ function M:NeedSunder(cfg)
 end
 
 -- ============================================================
+-- Bleed immunity
+-- ============================================================
+-- Mechanical and Elemental targets cannot be bled, so Rend never lands on them.
+-- Without this test the Rend gate below reads "the debuff is not on the target"
+-- forever and re-attempts it on EVERY press, burning a GCD and the rage each
+-- time. Cached per target id the same way the paladin caches creature type
+-- (Class_Paladin.lua): a mob's type never changes, so this costs one API call
+-- per target rather than one per press, and keying on the id (GUID based) means
+-- a target swap re-reads at once instead of answering from a stale cache.
+--
+-- An UNKNOWN type must ALLOW the cast: UnitCreatureType returns nil for some
+-- units, and failing open only risks the behaviour we already have today, while
+-- failing closed would silently disable Rend against ordinary mobs. Note the
+-- comparison is against English strings - UnitCreatureType is localised, so this
+-- degrades to "never immune" on a non-enUS client, which is the safe direction.
+function M:TargetIsBleedImmune()
+    local id = Aegis_SBR:TargetId()
+    if id ~= self.bleedTypeId then
+        local t = UnitCreatureType("target")
+        self.bleedTypeId = id
+        self.bleedImmune = (t == "Mechanical" or t == "Elemental")
+    end
+    return self.bleedImmune
+end
+
+-- ============================================================
 -- Rotation
 -- ============================================================
 function M:Rotate(cfg)
@@ -328,12 +354,28 @@ function M:Rotate(cfg)
             .. " elite=" .. (isElite and "Y" or "N"))
     end
 
+    -- Is a Charge opener pending? Resolved HERE, before the off-GCD layer,
+    -- because Bloodrage has to know about it. Bloodrage flags us in combat and
+    -- the Charge gate below is `not inCombat`, so firing Bloodrage on a pull
+    -- press does not merely go first - it disqualifies Charge for the rest of
+    -- the pull, which reads in game as "Charge never fires even in range".
+    -- (They also both issue a CastSpellByName in the same frame, which is
+    -- unreliable in 1.12 - a later call can override an earlier one.)
+    -- Holding Bloodrage for the one press costs nothing: Charge generates rage
+    -- by itself, and Bloodrage is still there the moment we land.
+    -- Stance is deliberately NOT part of this test - while we are dancing to
+    -- Battle the opener is still pending, so Bloodrage must keep waiting.
+    local chargePending = cfg.useCharge and self:KnowsSpell("Charge") and not inCombat
+        and UnitExists("target") and UnitCanAttack("player", "target")
+        and not UnitIsDeadOrGhost("target") and not self:InMeleeRange()
+
     -- ----------------------------------------------------------------
     -- 0. Off-GCD / on-next-swing layer (fire and continue, no return)
     -- ----------------------------------------------------------------
-    -- 0a. Bloodrage to keep rage flowing (works out of combat for pulls).
-    if cfg.useBloodrage and self:KnowsSpell("Bloodrage") and self:IsReady("Bloodrage")
-        and rage < (cfg.bloodrageRage or 30) then
+    -- 0a. Bloodrage to keep rage flowing (works out of combat for pulls), but
+    --     never while a Charge opener is pending - see chargePending above.
+    if cfg.useBloodrage and not chargePending and self:KnowsSpell("Bloodrage")
+        and self:IsReady("Bloodrage") and rage < (cfg.bloodrageRage or 30) then
         CastSpellByName("Bloodrage")
     end
 
@@ -387,9 +429,7 @@ function M:Rotate(cfg)
     --     with an attackable target. Stance-dances to Battle if enabled and
     --     needed. Charge itself is blocked by the client once you are in
     --     combat, so this naturally stops applying after the pull.
-    if cfg.useCharge and self:KnowsSpell("Charge") and not inCombat
-        and UnitExists("target") and UnitCanAttack("player", "target")
-        and not UnitIsDeadOrGhost("target") and not self:InMeleeRange() then
+    if chargePending then
         if self:InStance("Battle Stance") then
             if self:IsReady("Charge") then
                 if self:Cast("Charge") then return end
@@ -467,8 +507,11 @@ function M:Rotate(cfg)
 
     -- 1d2. Rend bleed upkeep (toggle; a leveling tool, off by default). Battle
     --      or Defensive stance, applied only when the bleed is not already on
-    --      the target. Skipped in the execute phase so rage funnels to Execute.
+    --      the target. Skipped in the execute phase so rage funnels to Execute,
+    --      and skipped entirely on bleed-immune targets, where the debuff can
+    --      never land and the "not up" test would otherwise re-cast forever.
     if cfg.useRend and not inExecute and self:KnowsSpell("Rend")
+        and not self:TargetIsBleedImmune()
         and self:CanCast("Rend", RAGE["Rend"], STANCE_REQ["Rend"])
         and not Aegis_SBR:TargetDebuffUp("Rend", "ability_rend") then
         if self:Cast("Rend") then return end


### PR DESCRIPTION
Two things: the changelog/version catch-up that v1.1.0 left behind, and two Warrior fixes from play reports.

## v1.1.3 — changelog for four already-merged PRs

`v1.1.0` was a docs-only cut, and the four code merges that landed after it never got version numbers or entries — `.toc`, core `ver`, and the README H1 all still read `1.1.0` with four features shipped on top. This writes a single entry covering the window, grouped by class:

| PR | Change |
|---|---|
| #30 | Rogue buff-renew slider (0–2s, replacing the hard-coded 5), opt-in Cold Blood, and the `/sbr log` press log + the trace-guard fix that made it work |
| #31 | Paladin Consecration opt-out from the latching mana-recovery hold, plus a creature-type cache |
| #33 | Sub-level-20 +healing penalty applied to downranked Holy Light |
| #34 | Warlock filler upgrades (your notes, kept verbatim) |

Two repairs along the way:

- **#32 gets no feature entry**, because it shipped nothing — the `holyLightPct` health gate was closed unmerged and superseded by #33. `c9ed20b` lives only on `feature/paladin-holy-light-health-gate`, is not an ancestor of `main`, and `holyLightPct` appears nowhere in the tree. It's recorded as an explicit *not shipped* note instead, since the two PRs address the same community report and the closure reasoning matters.
- **Structural fix at the top of the file.** The Warlock notes had been pasted directly under the `## v1.1.0` header, which orphaned the real v1.1.0 body below a separator and attributed Warlock work to a docs-only release. Notes kept verbatim, moved to where they belong.

## v1.1.4 — two Warrior fixes

Both were reported from play, reported back as a written diff, and **approved before any code changed**, per the no-silent-rotation-changes rule. **No priority ORDER moved:** one removes a disqualification, the other adds a gate.

**Charge is no longer killed by Bloodrage on the pull.** Bloodrage sits in the off-GCD layer and fired on any pull press where rage was under threshold — and out-of-combat rage is always 0, so that meant *every* pull press. It wasn't going first: Bloodrage flags combat, and Charge is gated on `not inCombat`, so from the next press onward Charge was unreachable for the whole pull. The symptom in game was Charge never firing even at perfect range. The two also both issued a `CastSpellByName` in the same frame, which 1.12 doesn't handle reliably. The viability test is hoisted into `chargePending` ahead of section 0 so both sites share one definition; waiting a press costs nothing because Charge generates the rage itself, and the hold deliberately survives a stance dance since the opener is still pending mid-dance.

**Rend is no longer spammed at targets that cannot bleed.** Mechanical and Elemental mobs are immune, so the debuff never lands, so the "not already on the target" test stayed true and Rend was re-attempted every press — a wasted GCD and 10 rage each time, all fight. New `TargetIsBleedImmune()` caches by target id on the pattern `Class_Paladin.lua` already uses for Exorcism: one `UnitCreatureType` call per target, not per press, and a target swap re-reads rather than answering stale.

Two deliberate choices worth reviewing:

- **Unknown creature type allows the cast.** `UnitCreatureType` returns nil for some units; failing open is no worse than today's behaviour, whereas failing closed would silently disable Rend against ordinary mobs.
- **The comparison is against English strings**, so this degrades to "never immune" on a non-enUS client — the safe direction, but it makes the fix enUS-only, consistent with the localisation gap already present in the combat-log parsing.

## Not addressed here

An Overpower report (the proc passed over for Slam and Heroic Strike) is deliberately **left alone**. Overpower already sits above the strikes and Slam in the list, so the cause is elsewhere — most likely the Battle Stance gate at `Class_Warrior.lua:422` when `stanceDance` is off, or `overpowerExpiry` being zeroed at `:423` before a cast that then fails (Revenge has the identical bug at `:407`). Awaiting a `/sbr log` capture to tell those apart rather than guessing at a hand-tuned priority list. The Warrior trace already carries an `op=Y/N` field for exactly this.

## Verification

- `python3 scripts/verify.py --all` passes (balance + define-before-use ordering)
- Version in sync across all three canonical spots: `.toc`, core `ver`, README H1
- All changelog version headers unique; no stale version strings
- No Lua 5.1+/retail constructs introduced

**Unverified assumption, stated plainly:** I did not confirm that Turtle 1.18.1 keeps vanilla's elemental/mechanical bleed immunity — `docs/turtle-mechanics.md` says nothing about it. If Turtle changed that, it's one condition to relax. Worth a spot-check against a mechanical mob when testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN

---
_Generated by [Claude Code](https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN)_