### PR TITLE
Shaman shock range, and a poison warning before the weapon runs dry

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -386,7 +386,13 @@ end
 -- ============================================================
 function Aegis_SBR:WeaponEnchant(slot)
     if not GetWeaponEnchantInfo then return false, nil, nil end
-    local hasMH, mhMs, mhCh, _, hasOH, ohMs, ohCh = GetWeaponEnchantInfo()
+    -- Six return values on 1.12, not seven: there is no enchant-id slot between
+    -- the hands on this client. Reading a seventh put hasOH on the off-hand
+    -- EXPIRATION, so WeaponEnchant("off") returned nonsense. Latent until now,
+    -- because the only caller asks for the main hand, where both readings agree.
+    -- The six-value form is the one Aegis_SBR_BuffUp uses and its charge counts
+    -- are confirmed correct in game.
+    local hasMH, mhMs, mhCh, hasOH, ohMs, ohCh = GetWeaponEnchantInfo()
     if slot == "off" then return (hasOH and true or false), ohMs, ohCh end
     return (hasMH and true or false), mhMs, mhCh
 end

--- a/Aegis_SBR_BuffUp.lua
+++ b/Aegis_SBR_BuffUp.lua
@@ -59,6 +59,17 @@ local QB_HALF_W = math.floor((62 - 2 * 4 - 2) / 2)  -- half-button bar width (QB
 local CAPTURE_DELAY = 1.5    -- wait this long after apply before first read
 local CAPTURE_TIMEOUT = 6.0  -- give up after this many seconds
 
+-- Low-charge warning for weapon poisons. A poison does not fade, it is USED UP:
+-- the charge counter is the only advance notice you get, and without it the
+-- first sign of trouble is the poison already being gone mid-fight.
+local POISON_LOW_CHARGES = 5
+-- Blink: a triangle wave over this period, never fading further than the floor
+-- so the label stays readable at every point of the cycle. Slow on purpose -
+-- this is a heads-up, not an alarm, and a fast flash in the middle of the
+-- screen is exhausting to play next to.
+local BLINK_PERIOD    = 1.4
+local BLINK_MIN_ALPHA = 0.35
+
 -- Rebuff-button stack sizing.
 local BTN_W = 184
 local BTN_H = 30
@@ -634,10 +645,33 @@ local function GetButton(index)
 end
 
 local function StyleButton(b, style)
-    if style == "poison" then
+    if style == "gone" then
+        -- Poison is off the weapon entirely - the strongest state on screen.
+        b:SetBackdropColor(0.24, 0.04, 0.04, 0.95); b:SetBackdropBorderColor(1, 0.25, 0.25, 0.95)
+    elseif style == "low" then
+        -- Still applied, but nearly used up.
+        b:SetBackdropColor(0.24, 0.19, 0.02, 0.95); b:SetBackdropBorderColor(1, 0.82, 0.10, 0.95)
+    elseif style == "poison" then
         b:SetBackdropColor(0.13, 0.05, 0.18, 0.95); b:SetBackdropBorderColor(0.7, 0.4, 0.9, 0.9)
     else
         b:SetBackdropColor(0.05, 0.13, 0.18, 0.95); b:SetBackdropBorderColor(0.4, 0.75, 0.95, 0.9)
+    end
+end
+
+-- Pulse a button's alpha, or hold it steady. Driven by the button's own
+-- OnUpdate rather than the module's shared timer, which only ticks once a
+-- second - far too coarse to fade anything smoothly.
+local function SetBlink(b, on)
+    if on then
+        b:SetScript("OnUpdate", function()
+            this.blinkT = math.mod((this.blinkT or 0) + (arg1 or 0), BLINK_PERIOD)
+            local phase = this.blinkT / BLINK_PERIOD
+            local k = (phase < 0.5) and (phase * 2) or ((1 - phase) * 2)
+            this:SetAlpha(BLINK_MIN_ALPHA + (1 - BLINK_MIN_ALPHA) * k)
+        end)
+    else
+        b:SetScript("OnUpdate", nil)
+        b:SetAlpha(1)
     end
 end
 
@@ -668,22 +702,35 @@ local function UpdateButtons()
     local missing = {}
 
     -- Poison rebuff prompts (rogue, poison control on).
+    -- Two states per hand, and the charge count is what separates them:
+    --   gone      - nothing on the weapon. Red.
+    --   low       - still applied, POISON_LOW_CHARGES or fewer left. Yellow,
+    --               blinking, and clickable to top the weapon up before it runs
+    --               dry mid-pull.
+    -- Both keep the existing rule that the poison must actually be in the bags:
+    -- a warning you cannot act on is noise, and a blinking button whose click
+    -- does nothing is worse than no button.
+    --
+    -- charges > 0 is required for the low state on purpose. A TIME-based weapon
+    -- enchant reports 0 charges on Turtle, and without that guard every such
+    -- enchant would sit there blinking "0 left" for its whole duration.
     if db.poisonControl and IsPoisonClass() then
-        local hasMH, _, _, hasOH = GetWeaponEnchantInfo()
-        if db.watchPoisonMH and not hasMH then
-            local nm, idx = GetRebuffPoisonName("mh")
-            if nm and FindPoisonInBags(nm) then
-                table.insert(missing, { label = "|cffdd99ffPoison: Mainhand|r", style = "poison",
-                    action = function() ABU:ApplyPoison(idx, "mh") end })
+        local hasMH, _, mhCharges, hasOH, _, ohCharges = GetWeaponEnchantInfo()
+        local function poisonPrompt(hand, has, charges, watched, label)
+            if not watched then return end
+            local nm, idx = GetRebuffPoisonName(hand)
+            if not (nm and FindPoisonInBags(nm)) then return end
+            if not has then
+                table.insert(missing, { label = "|cffff6060Poison: " .. label .. "|r", style = "gone",
+                    action = function() ABU:ApplyPoison(idx, hand) end })
+            elseif charges and charges > 0 and charges <= POISON_LOW_CHARGES then
+                table.insert(missing, { label = "|cffffd200" .. label .. ": " .. charges .. " left|r",
+                    style = "low", blink = true,
+                    action = function() ABU:ApplyPoison(idx, hand) end })
             end
         end
-        if db.watchPoisonOH and not hasOH then
-            local nm, idx = GetRebuffPoisonName("oh")
-            if nm and FindPoisonInBags(nm) then
-                table.insert(missing, { label = "|cffdd99ffPoison: Offhand|r", style = "poison",
-                    action = function() ABU:ApplyPoison(idx, "oh") end })
-            end
-        end
+        poisonPrompt("mh", hasMH, mhCharges, db.watchPoisonMH, "Mainhand")
+        poisonPrompt("oh", hasOH, ohCharges, db.watchPoisonOH, "Offhand")
     end
 
     -- Watched-buff rebuff prompts (all classes, buff monitor on).
@@ -711,6 +758,7 @@ local function UpdateButtons()
         b:ClearAllPoints()
         b:SetPoint("TOP", UIParent, "TOP", 0, BTN_START_Y - (i - 1) * BTN_SPACING)
         StyleButton(b, data.style)
+        SetBlink(b, data.blink)
         b.text:SetText(data.label)
         b.buffAction = data.action
         b:SetScript("OnClick", function() if this.buffAction then this.buffAction() end end)

--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -227,6 +227,25 @@ end
 function M:ShieldSpell(cfg) return self.SHIELDS[cfg.shield or "lightning"] or "" end
 function M:ShockSpell(cfg)  return self.SHOCKS[cfg.shock or "earth"] or "" end
 
+-- Shocks reach 20yd, Lightning Bolt 30. Without this check the rotation picks
+-- the shock first (correctly, it is the stronger use of the cooldown), the cast
+-- silently fails out of range, and the press is spent doing nothing at all -
+-- even though Lightning Bolt below it would have reached. Reported from play at
+-- level 4, where Earth Shock plus Lightning Bolt IS the whole rotation.
+--
+-- IsSpellInRange is the same API the default action bars use to red-tint an
+-- out-of-range icon. It returns nil when it cannot judge (no target, unknown
+-- spell); nil is treated as "in range" so an unanswerable check can never
+-- silence an ability that would otherwise have fired.
+function M:InSpellRange(spell)
+    if not spell or spell == "" then return false end
+    if not UnitExists("target") then return false end
+    if not IsSpellInRange then return true end
+    local r = IsSpellInRange(spell, "target")
+    if r == nil then return true end
+    return r == 1
+end
+
 -- Queue a known spell through SuperWoW's cast queue so a cast in progress is
 -- not clipped. Returns true if the spell is known and was issued.
 function M:Queue(name)
@@ -681,7 +700,8 @@ function M:RotateEnhancement(cfg)
     end
 
     -- P5 shock on its (shared) cooldown, consuming the Stormstrike buff
-    if shock ~= "" and self:KnowsSpell(shock) and self:IsReady(shock) then
+    if shock ~= "" and self:KnowsSpell(shock) and self:IsReady(shock)
+        and self:InSpellRange(shock) then
         if shock == "Flame Shock" then
             if self:MaintainFlameShock() then return end
         else
@@ -731,7 +751,7 @@ function M:RotateElemental(cfg)
     elseif self:ShockSpell(cfg) ~= "" then
         -- a non-Flame shock chosen: cast it on its cooldown as a nuke
         local shock = self:ShockSpell(cfg)
-        if self:KnowsSpell(shock) and self:IsReady(shock) then
+        if self:KnowsSpell(shock) and self:IsReady(shock) and self:InSpellRange(shock) then
             if self:Queue(shock) then return end
         end
     end
@@ -778,7 +798,8 @@ function M:RotateTank(cfg)
     end
 
     -- P4 Earth Shock (or chosen shock) on cooldown, the primary threat tool
-    if shock ~= "" and self:KnowsSpell(shock) and self:IsReady(shock) then
+    if shock ~= "" and self:KnowsSpell(shock) and self:IsReady(shock)
+        and self:InSpellRange(shock) then
         if shock == "Flame Shock" then
             if self:MaintainFlameShock() then return end
         else


### PR DESCRIPTION
Two unrelated player-facing fixes plus one latent bug found on the way.

## An out-of-range shock swallowed the press

Reported from play at **level 4**, where Earth Shock plus Lightning Bolt is the
entire rotation: beyond 20 yards nothing happened at all.

The rotation puts the shock first, which is correct — it is the stronger use of
the cooldown. But a shock reaches 20 yards and Lightning Bolt reaches 30, so
between those ranges the shock was chosen, failed silently, and the press did
nothing, even though the filler underneath it would have landed.

All three shock gates (Enhancement, Elemental, Tank) now require the shock to be
in range. `IsSpellInRange` is what the default action bars use to red-tint an
out-of-range icon; it answers nil when it cannot judge, and nil counts as *in
range*, so an unanswerable check can never be the reason an ability stays
silent.

**Confirmed working in game.**

## Poisons warn before they run out

A poison does not fade, it is used up — the charge counter is the only advance
notice there is. Until now the rebuff button appeared only once the poison was
already gone, which in practice means noticing mid-pull.

| charges | button |
|---|---|
| ≤ 5, still applied | **yellow**, blinking, shows the count (`Mainhand: 4 left`), click to top up |
| none left | **red** (was purple) |

The blink is a triangle wave over 1.4s that never fades below 35% opacity —
deliberately slow and never fully dark, because this is a heads-up and not an
alarm. It runs off the button's own `OnUpdate`; the module's shared timer ticks
once a second and cannot fade anything smoothly.

Two deliberate limits: the warning still requires the poison to be **in your
bags** (the rule the missing-poison button already followed — a blinking button
whose click does nothing is worse than no button), and it requires charges above
zero, because a *time*-based weapon enchant reports zero charges on Turtle and
would otherwise blink "0 left" for its whole duration. The shaman's weapon-imbue
prompt is untouched and stays purple.

## Found on the way

The core read `GetWeaponEnchantInfo` with **seven** return values and a gap,
while `Aegis_SBR_BuffUp` reads **six**. Six is correct on 1.12 — BuffUp's charge
counts are confirmed right in game — so the core was putting `hasOH` on the
off-hand *expiration* and `WeaponEnchant("off")` returned nonsense. Latent,
because its only caller asks for the main hand where both readings agree.
Corrected before anything gets wired to the off hand.

## Notes for review

Branched from `main`, not from #38, even though #38 also touches
`Class_Shaman.lua` and `Aegis_SBR_BuffUp.lua`. The shaman change was rebuilt
directly on the `main` version rather than carried across as a patch, so the
diff here removes exactly three condition lines and adds nothing from #38.

No CHANGELOG entry and no version bump — #38 is still open and touches both.
Those belong to the release cut once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)