### PR TITLE
Shaman: totems cost no press, and know where they are standing

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -69,6 +69,7 @@ function Aegis_SBR:InvalidateSpellIndex()
     Aegis_SBR.spellIndex = nil
     Aegis_SBR.spellRanks = nil
     Aegis_SBR.costCache  = nil   -- slots moved, and a talent may have changed a cost
+    Aegis_SBR.radiusCache = nil
 end
 
 function Aegis_SBR:FindSpellSlot(name)
@@ -143,6 +144,45 @@ function Aegis_SBR:SpellCost(name)
     -- behaviour that is worst to debug. Re-scanning costs one hidden tooltip.
     if cost then self.costCache[name] = cost end
     return cost
+end
+
+-- The radius a spell affects, in yards, or nil when the tooltip does not say.
+--
+-- Read rather than tabulated, for the same reason SpellCost is: a totem's reach
+-- differs per totem and per rank (a Magma hits eight yards, an aura totem
+-- twenty), and a guessed twenty would call a Magma "in range" from fifteen
+-- yards away while it is hitting nothing at all.
+--
+-- The number lives in the description text, not in the range field on line two
+-- - that one is how far you may CAST it, which for a totem is your own feet. So
+-- the left-hand lines are scanned for the first "N yards"; scanning the left
+-- side only is also what keeps the cast range on the right of line two out of
+-- it. Pattern and approach follow Call of Elements, which does the same read.
+function Aegis_SBR:SpellRadius(name)
+    if not self.radiusCache then self.radiusCache = {} end
+    local hit = self.radiusCache[name]
+    if hit then return hit end
+    local slot = self:FindSpellSlot(name)
+    if not slot then return nil end
+    if not scanTip then
+        scanTip = CreateFrame("GameTooltip", SCAN_TIP, nil, "GameTooltipTemplate")
+    end
+    scanTip:SetOwner(UIParent, "ANCHOR_NONE")
+    scanTip:ClearLines()
+    scanTip:SetSpell(slot, BOOKTYPE_SPELL)
+    local radius
+    for i = 2, 8 do
+        local fs = getglobal(SCAN_TIP .. "TextLeft" .. i)
+        local txt = fs and fs:GetText()
+        if txt then
+            local _, _, n = string.find(txt, "(%d+)%.?%d* +ya?r?ds?")
+            if n then radius = tonumber(n); break end
+        end
+    end
+    -- Only successful reads are cached, same as SpellCost: a tooltip that
+    -- failed to populate once must not freeze "no radius" in place.
+    if radius then self.radiusCache[name] = radius end
+    return radius
 end
 
 -- Can the player pay for this spell right now? UnitMana returns whichever
@@ -1343,6 +1383,7 @@ ev:SetScript("OnEvent", function()
         Aegis_SBR:Banner()
     elseif event == "CHARACTER_POINTS_CHANGED" then
         Aegis_SBR.costCache = nil
+        Aegis_SBR.radiusCache = nil
     elseif event == "SPELLS_CHANGED" then
         -- learning a spell or rank invalidates the spellbook index and any
         -- cached profile validity, both rebuilt lazily on the next use

--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -35,7 +35,7 @@ local M = Aegis_SBR:NewClassModule("SHAMAN")
 M.uiTitle = "Shaman"
 -- Rotate runs under Aegis_SBR:Preview without casting (see Pick/Later).
 M.previewReady = true
-M.uiHeight = 642
+M.uiHeight = 698
 M.meleeAutoAttack = false   -- melee swing is managed per-mode in the module
 
 -- Talent that grants the Clearcasting proc. It grants no spell, so KnowsSpell
@@ -98,6 +98,32 @@ local TOTEM_APPLY_GRACE = 3
 local TOTEM_RETRY = 1.5
 -- Confirmed casts that produced no aura before the name is written off.
 local TOTEM_MISS_MAX = 2
+
+-- How long Fire Nova Totem occupies the fire slot before it detonates. There is
+-- no API for the life of your own totem, so this is calibrated from play rather
+-- than read: at the original guess of 5s a tester reported Magma arriving
+-- "2-3 sec" after the nova went off, which is that guess overshooting.
+--
+-- Wrong in either direction costs something, and they are not symmetric: too
+-- LOW replaces a nova that has not detonated yet and throws its damage away,
+-- too HIGH just leaves the slot empty for a moment. So this errs slightly
+-- toward late.
+local NOVA_STAND = 2.5
+
+-- Set by MaintainAllTotems from the profile, read by MaintainTotem.
+local cfgTotemRange = false
+
+-- Fallback radius in yards, used only when the tooltip cannot be read. Real
+-- radii come from Aegis_SBR:SpellRadius per totem.
+local TOTEM_RANGE = 20
+-- Tolerance on the radius, so a totem sitting exactly on the boundary does not
+-- flicker between "in" and "out" with every step. Call of Elements uses the
+-- same 7%.
+local TOTEM_RANGE_SLACK = 1.07
+-- The four element slots, in one place so range checks and the recall can walk
+-- them without repeating the list.
+local TOTEM_SLOTS = { "water", "earth", "fire", "air" }
+local RECALL_SPELL = "Totemic Recall"
 
 local TOTEM_REDROP_DEFAULT = 110
 local TOTEM_REDROP = {
@@ -225,6 +251,11 @@ function M:NormalizeProfile(c)
     -- AoE fire pair (Fire Nova on cooldown + Magma between). Off by default:
     -- it takes over the fire slot from the single-totem picker.
     if c.aoeFireTotems == nil then c.aoeFireTotems = false end
+    -- Both off by default: they depend on SuperWoW position data that has not
+    -- been verified in play yet, and a wrong distance would re-drop totems (and
+    -- burn mana) for no reason.
+    if c.totemRange == nil then c.totemRange = false end
+    if c.totemRecall == nil then c.totemRecall = false end
     if c.totemWater == nil then c.totemWater = "manaspring" end
     if c.totemEarth == nil then c.totemEarth = "none" end
     if c.totemFire == nil then c.totemFire = "none" end
@@ -441,6 +472,11 @@ function M:RunsWithoutTarget(cfg)
     if cfg.mode == "restoration" then return true end   -- a healer runs with no enemy targeted
     -- Pre-pull imbue upkeep is a self-buff and must run with no target selected.
     if self:ImbueState(cfg) then return true end
+    -- Totemic Recall matters precisely when there is no enemy left: you have
+    -- walked away and the totems are standing where the fight was. Gating it
+    -- behind a target meant it only ever fired mid-combat, which is the one
+    -- moment you do not want it.
+    if self:RecallDue(cfg) then return true end
     return false
 end
 
@@ -609,6 +645,15 @@ M.totemT = {}
 -- totem was really placed - Queue() cannot tell us, it reports success as soon
 -- as the spell is merely known.
 M.totemCastT = {}
+-- The totem's UNIT, per element slot. SuperWoW makes a placed totem an
+-- addressable unit, which is the only way to measure the real distance to it -
+-- and that in turn is the only signal available for the totems that grant no
+-- aura at all (Searing, Magma, Fire Nova, Grounding). Learned from
+-- UNIT_MODEL_CHANGED at the bottom of this file; the technique is Call of
+-- Elements'.
+M.totemGuid = {}
+-- Which totem is standing in each slot, so its own radius can be looked up.
+M.totemSpell = {}
 -- Last ATTEMPT per element slot, successful or not. Purely a throttle: without
 -- it a totem that cannot be cast (no mana) would claim every single press and
 -- starve the rest of the rotation, because Queue always says yes.
@@ -650,6 +695,100 @@ function M:OnCastEvent(caster, target, spellName)
     end
 end
 
+-- Distance from the player to the totem standing in this slot, in yards, or
+-- nil when it cannot be measured (no SuperWoW, totem never seen, totem gone).
+-- nil always means "cannot judge" and must never be read as "out of range".
+function M:TotemDistance(slot)
+    if not UnitPosition then return nil end
+    local guid = self.totemGuid[slot]
+    if not guid or not UnitExists(guid) then return nil end
+    local x1, y1, z1 = UnitPosition("player")
+    local x2, y2, z2 = UnitPosition(guid)
+    if not (x1 and x2) then return nil end
+    local dx, dy, dz = x2 - x1, y2 - y1, z2 - z1
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+-- How far this totem actually reaches. A Magma covers a fraction of what an
+-- aura totem does, so a single number for all four would be wrong for half of
+-- them - and wrong in the expensive direction, calling a totem useful while it
+-- hits nothing.
+function M:TotemRadius(slot)
+    local spell = self.totemSpell[slot]
+    local r = spell and Aegis_SBR:SpellRadius(spell)
+    if not r or r <= 0 then r = TOTEM_RANGE end
+    return r * TOTEM_RANGE_SLACK
+end
+
+function M:TotemOutOfRange(slot)
+    local d = self:TotemDistance(slot)
+    if not d then return false end
+    return d >= self:TotemRadius(slot)
+end
+
+-- Is anyone else in the group still standing in this totem's radius? A shaman
+-- who has walked off is not reason enough to pull a totem the party is still
+-- using - Mana Spring and Healing Stream serve the group, not the caster.
+function M:GroupNearTotem(guid, radius)
+    if not UnitPosition then return false end
+    local x2, y2, z2 = UnitPosition(guid)
+    if not x2 then return false end
+    local prefix, count = "raid", GetNumRaidMembers()
+    if count == 0 then prefix, count = "party", GetNumPartyMembers() end
+    for i = 1, count do
+        local u = prefix .. i
+        if UnitExists(u) and not UnitIsUnit(u, "player") and not UnitIsDeadOrGhost(u) then
+            local x1, y1, z1 = UnitPosition(u)
+            if x1 then
+                local dx, dy, dz = x2 - x1, y2 - y1, z2 - z1
+                if math.sqrt(dx * dx + dy * dy + dz * dz) < (radius or TOTEM_RANGE) then return true end
+            end
+        end
+    end
+    return false
+end
+
+-- Totemic Recall: pull every totem back and get a quarter of their mana back.
+--
+-- Only when EVERY standing totem is out of reach, because the spell recalls all
+-- of them at once - with three good totems and one stranded, recalling would
+-- throw the three away for a sliver of mana. And only when no group member is
+-- still inside one of them.
+--
+-- The gain is smaller than the 25% suggests: the totems are re-placed at full
+-- cost afterwards, so it saves a quarter of one placement. What makes it worth
+-- having is the side effect - the slots read as empty immediately and get
+-- re-dropped where the shaman actually is, instead of waiting out the timer.
+-- Split from the cast so the core can be told "this module has something to do
+-- even with no target selected" without a preview or a check firing the spell.
+function M:RecallDue(cfg)
+    if not cfg.totemRecall then return false end
+    if not UnitPosition then return false end
+    if not self:KnowsSpell(RECALL_SPELL) then return false end
+    if not self:OwnCDReady(RECALL_SPELL) then return false end
+
+    local standing, stranded = 0, 0
+    for i = 1, table.getn(TOTEM_SLOTS) do
+        local slot = TOTEM_SLOTS[i]
+        local guid = self.totemGuid[slot]
+        if guid and UnitExists(guid) then
+            standing = standing + 1
+            if self:TotemOutOfRange(slot) and not self:GroupNearTotem(guid, self:TotemRadius(slot)) then
+                stranded = stranded + 1
+            end
+        end
+    end
+    return standing > 0 and stranded == standing
+end
+
+function M:RecallTotems(cfg)
+    if not self:RecallDue(cfg) then return false end
+    -- Treated as an off-GCD extra like the totems themselves. If it turns out
+    -- to cost a global cooldown after all, this spends one - rarely, and only
+    -- while walking away from a fight.
+    return self:PickExtra(RECALL_SPELL)
+end
+
 -- The aura a totem grants, as the CLIENT names it - returned as two candidates
 -- because our table is a guess and the two forms differ per totem for no
 -- discernible reason (Windfury Totem keeps the word, Stoneskin drops it).
@@ -684,9 +823,21 @@ function M:TryTotem(key, spell, now)
     -- from the spellbook tooltip, and an unreadable cost counts as affordable,
     -- so this can never be the reason a totem stays down.
     if Aegis_SBR.CanAfford and not Aegis_SBR:CanAfford(spell) then return false end
-    if not self:Queue(spell, "totem upkeep") then return false end
+    -- PickExtra, not Queue: with Nampower a totem costs no global cooldown, so
+    -- it rides along in the same press as whatever the rotation is doing rather
+    -- than spending a press of its own.
+    if not self:PickExtra(spell) then return false end
     self:Later(function() self.totemTryT[key] = now end)
-    if not SpellInfo then self:Later(function() self.totemT[key] = now end) end
+    if not SpellInfo then
+        -- No cast event on this client, so the attempt has to stand in for both
+        -- clocks. The per-spell one matters for the AoE fire pair, which judges
+        -- Magma by when Magma itself was last placed - without this it would
+        -- read "never placed" forever and re-drop on every retry.
+        self:Later(function()
+            self.totemT[key] = now
+            self.totemCastT[spell] = now
+        end)
+    end
     return true
 end
 
@@ -701,6 +852,14 @@ end
 function M:MaintainTotem(key, spell, interval)
     if spell == "" or not self:KnowsSpell(spell) then return false end
     local now = GetTime()
+
+    -- Walked out of its radius: the totem is standing but doing nothing for us,
+    -- so it counts as missing regardless of aura or clock. This is the only
+    -- check that covers the totems granting no aura at all, which are exactly
+    -- the ones the blind timer serves worst.
+    if cfgTotemRange and self:TotemOutOfRange(key) then
+        return self:TryTotem(key, spell, now)
+    end
     local mapped, own = self:TotemBuffNames(spell)
 
     if mapped then
@@ -765,7 +924,7 @@ function M:MaintainFireTotems(cfg)
     if not haveNova and not haveMagma then return false end
 
     if haveNova and self:OwnCDReady(nova) then
-        if self:Queue(nova, "AoE, on cooldown") then
+        if self:PickExtra(nova) then
             -- Same rule as TryTotem: with the cast event the stamp comes from
             -- the cast that actually happened, not from the attempt.
             self:Later(function()
@@ -774,31 +933,81 @@ function M:MaintainFireTotems(cfg)
             end)
             -- Nova occupies the slot only briefly; letting Magma follow as soon
             -- as it has detonated is the point of the pairing.
-            self:Later(function() self.novaUntil = GetTime() + 5 end)
+            self:Later(function() self.novaUntil = GetTime() + NOVA_STAND end)
             return true
         end
     end
-    -- Hold Magma back while a Nova is still standing - re-dropping would
-    -- replace it and waste the detonation it was cast for.
+    -- Magma fills the gap, but it may NOT be judged by the element slot's clock
+    -- the way a normal totem is. That clock is stamped by any fire totem, Fire
+    -- Nova included, so with Nova's ~15s cooldown against Magma's 18s interval
+    -- the window never opened once - reported from play as "Magma Totem does
+    -- not get placed at all".
+    --
+    -- The right clock is Magma's OWN last cast, plus one extra rule: a Nova
+    -- since then has replaced it, so it is due again the moment that Nova has
+    -- detonated. Both timestamps are already kept per spell by OnCastEvent.
     if haveMagma and GetTime() >= (self.novaUntil or 0) then
-        if self:MaintainTotem("fire", magma) then return true end
+        local now = GetTime()
+        local lastMagma = self.totemCastT[magma] or 0
+        local lastNova  = self.totemCastT[nova] or 0
+        local due = (lastMagma == 0)                                    -- never placed
+            or (lastNova > lastMagma)                                   -- a Nova replaced it
+            or ((now - lastMagma) >= (TOTEM_REDROP[magma] or TOTEM_REDROP_DEFAULT))
+        if due and self:TryTotem("fire", magma, now) then return true end
     end
     return false
 end
 
+-- Totem upkeep, as off-GCD EXTRAS.
+--
+-- With Nampower a totem is instant and costs no global cooldown, so upkeep does
+-- not compete with the rotation at all - which is why these used to sit near
+-- the bottom of every priority list and why that position no longer matters.
+-- The callers therefore do NOT return on a hit.
+--
+-- All four go out in a single press when Nampower is present; see the queue
+-- test inside for why that condition and not a blanket one-per-press rule.
 function M:MaintainAllTotems(cfg)
     if cfg.useTotems == false then return false end
-    if self:MaintainTotem("water", self.WATER_TOTEMS[cfg.totemWater or "none"] or "") then return true end
-    if self:MaintainTotem("earth", self.EARTH_TOTEMS[cfg.totemEarth or "none"] or "") then return true end
+    -- MaintainTotem is called from several places without cfg, so the toggle is
+    -- handed over here rather than threaded through every signature.
+    cfgTotemRange = cfg.totemRange and true or false
+    if self:RecallTotems(cfg) then return true end
+
+    -- All four in one press when the client can take it, one otherwise. The
+    -- condition is the presence of the Nampower queue API, which is the same
+    -- test Call of Elements uses for the same reason: without it a second
+    -- CastSpellByName in the same frame overrides the first instead of being
+    -- queued behind it, so only one totem would actually land.
+    --
+    -- Nampower is a hard requirement for this addon, so the single-cast path is
+    -- a safety net rather than a supported mode.
+    local oneOnly = (QueueSpellByName == nil)
+    local did = false
+
+    if self:MaintainTotem("water", self.WATER_TOTEMS[cfg.totemWater or "none"] or "") then
+        did = true
+        if oneOnly then return true end
+    end
+    if self:MaintainTotem("earth", self.EARTH_TOTEMS[cfg.totemEarth or "none"] or "") then
+        did = true
+        if oneOnly then return true end
+    end
     -- The AoE pair owns the fire slot when enabled, so the single-totem picker
     -- is skipped rather than fighting it for the same slot.
     if cfg.aoeFireTotems then
-        if self:MaintainFireTotems(cfg) then return true end
+        if self:MaintainFireTotems(cfg) then
+            did = true
+            if oneOnly then return true end
+        end
     elseif self:MaintainTotem("fire", self.FIRE_TOTEMS[cfg.totemFire or "none"] or "") then
-        return true
+        did = true
+        if oneOnly then return true end
     end
-    if self:MaintainTotem("air",   self.AIR_TOTEMS[cfg.totemAir or "none"] or "") then return true end
-    return false
+    if self:MaintainTotem("air", self.AIR_TOTEMS[cfg.totemAir or "none"] or "") then
+        did = true
+    end
+    return did
 end
 
 -- Heal decision. Casts one spell per press via early return.
@@ -806,6 +1015,11 @@ end
 -- (single-target emergency, wins over AoE) -> Chain Heal (AoE) -> downranked
 -- Healing Wave (fill) -> Water Shield upkeep -> totem upkeep (during downtime).
 function M:RotateRestoration(cfg)
+    -- Above the GCD guard on purpose: totems cost no global cooldown, so a
+    -- resto shaman can keep them up straight through a heal cast. Everything
+    -- below this line is a real cast and has to wait for the GCD.
+    self:MaintainAllTotems(cfg)
+
     if not self:GcdReady() then return end
 
     local ratio = (cfg.healThreshold or 90) / 100
@@ -862,12 +1076,6 @@ function M:RotateRestoration(cfg)
 
     -- Nothing urgent: keep the shield and totems up during the lull.
     if self:MaintainShield(cfg) then return end
-    if cfg.useTotems ~= false then
-        -- Shared helper rather than four copies of the same calls: Restoration
-        -- had its own duplicate set, so anything added centrally (the AoE fire
-        -- pair, the per-totem intervals) silently skipped this spec.
-        if self:MaintainAllTotems(cfg) then return end
-    end
     -- Weapon imbue upkeep: below every heal and totem, above the optional
     -- damage weave. Restoration reaches this only when nothing needs healing,
     -- so an imbue can never take the global cooldown away from a heal - but a
@@ -900,6 +1108,9 @@ function M:Rotate(cfg)
     -- rotations below never run without an enemy.
     local hasEnemy = UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
     if not hasEnemy then
+        -- Off the global cooldown and unrelated to any target, so it belongs
+        -- here as much as in combat.
+        self:RecallTotems(cfg)
         self:MaintainImbue(cfg)
         return
     end
@@ -939,6 +1150,13 @@ function M:RotateEnhancement(cfg)
             .. " mana=" .. string.format("%.0f", self:ManaPct()))
     end
 
+    -- Totem upkeep runs FIRST, because it is off the global cooldown: it rides
+    -- along with whatever this press does rather than competing with it. It has
+    -- to sit above the early returns below - down at the bottom it would only
+    -- ever be reached on a press where nothing else fired, which is the very
+    -- problem being fixed.
+    self:MaintainAllTotems(cfg)
+
     -- P1 shield upkeep
     if self:MaintainShield(cfg) then return end
 
@@ -976,9 +1194,6 @@ function M:RotateEnhancement(cfg)
         end
     end
 
-    -- P7 Totem upkeep (all four elements, timer/cast-event gated, low priority)
-    if self:MaintainAllTotems(cfg) then return end
-
     -- P8 Lightning Bolt filler / weave. Also the level 1 damage source.
     if cfg.lbFiller and self:KnowsSpell("Lightning Bolt") then
         self:Queue("Lightning Bolt", "filler")
@@ -997,6 +1212,13 @@ function M:RotateElemental(cfg)
             .. " EM=" .. (cfg.useElementalMastery and (self:KnowsSpell("Elemental Mastery") and "Y" or "n") or "-")
             .. " mana=" .. string.format("%.0f", self:ManaPct()))
     end
+
+    -- Totem upkeep runs FIRST, because it is off the global cooldown: it rides
+    -- along with whatever this press does rather than competing with it. It has
+    -- to sit above the early returns below - down at the bottom it would only
+    -- ever be reached on a press where nothing else fired, which is the very
+    -- problem being fixed.
+    self:MaintainAllTotems(cfg)
 
     -- P1 shield upkeep (Water Shield for mana by default)
     if self:MaintainShield(cfg) then return end
@@ -1025,9 +1247,6 @@ function M:RotateElemental(cfg)
         end
     end
 
-    -- P5 Totem upkeep (all four elements)
-    if self:MaintainAllTotems(cfg) then return end
-
     -- P6 Lightning Bolt filler, the main nuke (builds Electrify). Always the
     -- level 1 fallback.
     if self:KnowsSpell("Lightning Bolt") then
@@ -1049,6 +1268,13 @@ function M:RotateTank(cfg)
             .. " ls=" .. (cfg.useLightningStrike and (self:KnowsSpell("Lightning Strike") and "Y" or "n") or "-")
             .. " taunt=" .. (cfg.useTaunt and (self:KnowsSpell("Earthshaker Slam") and "Y" or "n") or "-"))
     end
+
+    -- Totem upkeep runs FIRST, because it is off the global cooldown: it rides
+    -- along with whatever this press does rather than competing with it. It has
+    -- to sit above the early returns below - down at the bottom it would only
+    -- ever be reached on a press where nothing else fired, which is the very
+    -- problem being fixed.
+    self:MaintainAllTotems(cfg)
 
     -- P1 shield upkeep (Lightning Shield for threat)
     if self:MaintainShield(cfg) then return end
@@ -1094,9 +1320,6 @@ function M:RotateTank(cfg)
         and self:InSpellRange("Lightning Strike") then
         if self:Queue("Lightning Strike", "on cooldown") then return end
     end
-
-    -- P7 Totem upkeep (all four elements)
-    if self:MaintainAllTotems(cfg) then return end
 
     -- P8 optional Lightning Bolt filler (off by default for tanks)
     if cfg.lbFiller and self:KnowsSpell("Lightning Bolt") then
@@ -1164,4 +1387,29 @@ talentFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 talentFrame:RegisterEvent("CHARACTER_POINTS_CHANGED")
 talentFrame:SetScript("OnEvent", function()
     M.talentCache = nil
+end)
+
+-- ============================================================
+-- Totem units. SuperWoW reports a freshly placed totem through
+-- UNIT_MODEL_CHANGED with a GUID in arg1; "<guid>owner" resolves to whoever
+-- summoned it, which is what separates our own totems from every other one in
+-- the raid. The unit name carries the totem's spell name, so it maps straight
+-- onto the element slot. Borrowed from Call of Elements, which uses the same
+-- two facts to measure distance to a totem.
+--
+-- Registered only when UnitPosition exists: without SuperWoW the GUID would be
+-- useless anyway, and every distance check degrades to "cannot judge".
+-- ============================================================
+local totemWatch = CreateFrame("Frame")
+if UnitPosition then totemWatch:RegisterEvent("UNIT_MODEL_CHANGED") end
+totemWatch:SetScript("OnEvent", function()
+    if not arg1 then return end
+    if not UnitIsUnit(arg1 .. "owner", "player") then return end
+    local _, _, name = string.find(UnitName(arg1) or "", "^(.- Totem)")
+    if not name then return end
+    local slot = M:TotemElementMap()[name]
+    if slot then
+        M.totemGuid[slot] = arg1
+        M.totemSpell[slot] = name
+    end
 end)

--- a/classes/Class_Shaman_UI.lua
+++ b/classes/Class_Shaman_UI.lua
@@ -44,6 +44,10 @@ function M:BuildBody(ui, parent)
     self.earthDD = L:Dropdown("totemEarth", "Earth totem", 160, set("totemEarth"))
     self.fireDD  = L:Dropdown("totemFire", "Fire totem", 160, set("totemFire"))
     self.aoeFireRow = L:Row{ key = "aoeFireTotems", label = "AoE fire pair (Nova + Magma)", onToggle = set("aoeFireTotems") }
+    -- Both need SuperWoW: a placed totem is only addressable as a unit there,
+    -- and without that there is no distance to measure.
+    self.totemRangeRow = L:Row{ key = "totemRange", label = "Re-place when out of range", onToggle = set("totemRange") }
+    self.totemRecallRow = L:Row{ key = "totemRecall", label = "Totemic Recall when left behind", onToggle = set("totemRecall") }
     self.airDD   = L:Dropdown("totemAir", "Air totem", 160, set("totemAir"))
 
     L:Header("Cooldowns & utility")
@@ -106,6 +110,8 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.chainRow.slider, "Chain Heal count", "How many hurt allies are needed before Chain Heal fires.")
     ui:Tip(self.totemsRow.cb, "Maintain totems", "Keeps the totems below dropped in every spec, re-cast during a lull. Cast timing is tracked from your actual casts (SuperWoW), not a blind clock.")
     ui:Tip(self.aoeFireRow.cb, "AoE fire pair (Nova + Magma)", "Takes over the fire slot: Fire Nova Totem every time its cooldown is up, Magma Totem in between to keep the ground ticking.", "The two cannot both sit in the picker above, because the point is to alternate them - Fire Nova detonates after a few seconds and then waits on a cooldown, so it behaves like a cooldown ability while Magma is the sustained damage. They share one totem slot in game, so Magma is held back while a Nova is still standing rather than replacing the detonation you just paid for. While this is on, the fire picker above is ignored.")
+    ui:Tip(self.totemRangeRow.cb, "Re-place when out of range", "Measures the real distance to your own totems and treats one you have walked away from as missing, so it is re-placed where you actually are.", "This is the only check that works for the totems granting no aura at all - Searing, Magma, Fire Nova, Grounding - which the blind timer serves worst: it happily counts down on a totem the group left behind two rooms ago. Needs SuperWoW; without it there is no distance to measure and nothing changes.")
+    ui:Tip(self.totemRecallRow.cb, "Totemic Recall when left behind", "Pulls all totems back for a quarter of their mana once every one of them is out of reach and nobody in the group is standing in them either.", "All-or-nothing on purpose: the spell recalls every totem at once, so with three still doing their job it would throw those away for a sliver of mana. The group check matters for Mana Spring and Healing Stream, which serve the party rather than you. The real gain is less the mana than the slots reading as empty immediately, so they are re-dropped where you are instead of waiting out the timer.")
     ui:Tip(self.weaveRow.cb, "Weave damage", "When nobody needs healing and you have an enemy targeted, cast Lightning Bolt in the downtime.", "Mana-gated so it never starves heals. Off by default - same as /sbr weave on|off.")
     ui:Tip(self.weaveRow.slider, "Weave mana floor", "Only weave damage while your mana is above this percent.")
     ui:Tip(self.waterDD, "Water totem", "Which water totem to keep down. Mana Spring restores party mana.")
@@ -206,6 +212,8 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.chainRow, buf.useChainHeal ~= false, "Chain Heal")
     ui:BindCheck(self.totemsRow, buf.useTotems ~= false)
     ui:BindCheck(self.aoeFireRow, buf.aoeFireTotems)
+    ui:BindCheck(self.totemRangeRow, buf.totemRange)
+    ui:BindCheck(self.totemRecallRow, buf.totemRecall)
     -- The picker and the pair own the same slot, so whichever is inactive is
     -- greyed rather than left looking as if both apply.
     if buf.aoeFireTotems then


### PR DESCRIPTION
Three pieces of player feedback on the shaman. The first two are **confirmed in
play**; the third ships behind two switches that are **off by default**.

## Totem upkeep no longer spends a press

With Nampower a totem is instant *and* off the global cooldown, so upkeep has no
business competing with the rotation — which is why it used to sit near the
bottom of every priority list and lose to shocks and strikes for whole fights.

They are **off-GCD extras** now, riding along with whatever the press was already
doing, and the call moved to the **top** of all four rotations. That second part
matters: as an extra sitting at the bottom it would only ever be reached on a
press where nothing else fired — the same bug in new clothes. Restoration gets it
above the GCD guard too, so a healer keeps totems up straight through a cast.

All four go out in **one press**, gated on `QueueSpellByName` being present. Same
test Call of Elements uses, same reason: without the queue API a second
`CastSpellByName` in one frame overrides the first, so only one totem would land.

Tester: *"maintaining totems work now"*, and both his totems now land near-instantly.

## Magma never got placed

Reported as *"the Fire Nova/Magma pair seems only to work for Fire Nova"*.

Magma grants no aura, so it ran on a timer — and the timer it read was the fire
**slot's** clock, which any fire totem stamps, Nova included. Magma's interval is
18s, Nova's cooldown ~15s:

```
t=0   Nova cast, slot clock = 0, Magma blocked until 18
t=15  Nova off cooldown, cast again, slot clock = 15
t=20  Magma blocked until 33 … Nova fires again at 30
```

The window never opened once. Magma is now judged by when **Magma** was last
cast, plus: a Nova since then has replaced it, so it is due again the moment that
Nova detonates.

The hold protecting a standing Nova was a guessed 5s and overshot — a tester saw
Magma arrive *"2-3 sec"* late. Now a named `NOVA_STAND = 2.5`, biased toward late
on purpose: too early replaces a Nova that has not exploded and wastes it, too
late only leaves the slot empty for a moment.

## Knowing where a totem is (opt-in)

SuperWoW makes a placed totem an addressable unit: `UNIT_MODEL_CHANGED` carries a
GUID, `"<guid>owner"` says who summoned it, the unit name is the spell name, and
`UnitPosition` on that GUID gives a real distance. All of it lifted from Call of
Elements.

This is the **only** signal that works for the totems granting no aura at all —
Searing, Magma, Fire Nova, Grounding — which are exactly the ones the blind timer
serves worst: it counts down happily on a totem the group left two rooms behind.

| switch | what it does |
|---|---|
| **Re-place when out of range** | A totem you walked away from counts as missing. Measured against its **own** radius, read from the tooltip (new `SpellRadius` in the core), with the same 7% tolerance CoE uses so a totem on the boundary does not flicker. |
| **Totemic Recall when left behind** | Pulls everything back for a quarter of the mana — but only when **every** standing totem is out of reach, and only when no group member is standing in one. |

Both conditions on the recall are deliberate. The spell recalls *all* totems, so
firing it with three still working would throw those away. And CoE measures from
the player alone, which is wrong for Mana Spring and Healing Stream — a healer
standing back would pull a totem the party is still using.

The recall also runs with **no target selected**. Gating it behind a target meant
it only ever fired mid-combat, the one moment you do not want it. Totem
*placement* stays gated on a target on purpose: Searing and Magma attack, and a
fire totem planting itself before a pull would pick the fight for you.

## Note on the commits

I had meant to split the confirmed work from the opt-in feature so the latter
could be reverted on its own. On inspection the two interleave inside three
hunks, and splitting them by hand would mean surgery on a file nobody here can
test. The feature is already isolated behind two default-off switches, which
gives the same safety without the risk — so the split is by responsibility
(core / class) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)