### PR TITLE
Hunter: a pet window, and a sting that comes back after a miss

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -1227,6 +1227,17 @@ function Aegis_SBR:EvalCommand(msg)
     if cmd == "check" then self:CmdCheck(); return end
     if cmd == "reset" then self:CmdReset(); return end
     if cmd == "acquire" then self:CmdAcquire(t[2], t[3]); return end
+    -- Toggles the pet window without going through the class panel, which is
+    -- also how to tell a broken window apart from a broken switch.
+    if cmd == "pet" then
+        if Aegis_SBR_Pet then
+            local on = Aegis_SBR_Pet:Toggle()
+            msgOut("pet window " .. (on and "shown" or "hidden") .. ".")
+        else
+            msgOut("pet window module not loaded.", 1, 0.5, 0.3)
+        end
+        return
+    end
     if cmd == "minimap" then
         if Aegis_SBR_Minimap and Aegis_SBR_Minimap.ToggleShown then
             local hidden = Aegis_SBR_Minimap:ToggleShown()
@@ -1330,6 +1341,7 @@ function Aegis_SBR:OnAddonLoaded()
     -- Saved variables are in by now, so the preview window can restore whether
     -- it was open. Guarded because the file is optional in the load order.
     if Aegis_SBR_Preview then Aegis_SBR_Preview:Restore() end
+    if Aegis_SBR_Pet then Aegis_SBR_Pet:Restore() end
 end
 
 -- Printed once at PLAYER_LOGIN, when the chat frame is ready. ADDON_LOADED

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -10,6 +10,7 @@ Aegis_SBR_UI.lua
 Aegis_SBR_BuffUp.lua
 Aegis_SBR_Minimap.lua
 Aegis_SBR_Preview.lua
+Aegis_SBR_Pet.lua
 classes\Class_Druid.lua
 classes\Class_Druid_UI.lua
 classes\Class_Hunter.lua

--- a/Aegis_SBR_Pet.lua
+++ b/Aegis_SBR_Pet.lua
@@ -1,0 +1,245 @@
+-- ============================================================
+-- Aegis_SBR_Pet  -  a small always-on pet readout
+--
+-- Level, experience toward the next level, and happiness. All of it is in the
+-- default Pet Details panel already; the point here is a window small enough to
+-- leave on screen, so the state is glanceable instead of something you open a
+-- frame to check.
+--
+-- The border carries the happiness, because that is the part you act on: green
+-- happy, yellow content, red unhappy. Colour reaches you across the screen in a
+-- way a number does not.
+--
+-- Toggled from the Hunter panel; visibility, position and scale live in
+-- AegisDB.petWindow.
+-- ============================================================
+
+Aegis_SBR_Pet = {}
+local AP = Aegis_SBR_Pet
+
+local TICK = 0.5          -- the readout changes slowly; twice a second is plenty
+local BASE_W = 176
+local MIN_SCALE, MAX_SCALE = 0.6, 2.0
+
+-- Border thickness in pixels. The stock tooltip edge is a thin ornamental line
+-- and only gets blurry when scaled up, so the border is four solid bars instead
+-- - a colour you are meant to read across the room wants to be a block, not a
+-- hairline. One number to tune.
+local BORDER_W = 2
+
+-- Happiness is 1 unhappy, 2 content, 3 happy. The border takes these; the
+-- damage figure beside the label is what the number actually costs you.
+local HAPPY = {
+    [1] = { label = "Unhappy", r = 0.85, g = 0.15, b = 0.15 },
+    [2] = { label = "Content", r = 0.95, g = 0.80, b = 0.10 },
+    [3] = { label = "Happy",   r = 0.25, g = 0.80, b = 0.30 },
+}
+
+local COL_BG    = { 0.05, 0.05, 0.07, 0.92 }
+local COL_TEXT  = { 0.85, 0.86, 0.90 }
+local COL_MUTE  = { 0.55, 0.57, 0.62 }
+local COL_TITLE = { 0.55, 0.57, 0.62 }
+
+function AP:DB()
+    if not AegisDB then return nil end
+    if type(AegisDB.petWindow) ~= "table" then AegisDB.petWindow = {} end
+    local db = AegisDB.petWindow
+    -- Deliberately no learned timings here. A countdown to the next loyalty
+    -- level was built and removed: the client exposes no progress within a
+    -- level, so it had to be measured - and a zone change dismisses the pet for
+    -- a moment, which is indistinguishable from a level starting. The clock
+    -- restarted on every zone line and the estimate was worthless. Loyalty is
+    -- shown as the level it is; the game does not know more than that either.
+    return db
+end
+
+function AP:Enabled()
+    local db = self:DB()
+    return db and db.shown and true or false
+end
+
+-- Loyalty level as a number, plus whatever text the client gives. Two readings
+-- are in circulation and both are covered: GetPetLoyalty may hand back a number
+-- first, or a single description string with the level in it.
+function AP:Loyalty()
+    if not GetPetLoyalty then return nil, nil end
+    local a, b = GetPetLoyalty()
+    local lvl = tonumber(a)
+    local text = b
+    if not lvl and type(a) == "string" then
+        text = a
+        local _, _, d = string.find(a, "(%d+)")
+        lvl = tonumber(d)
+    end
+    -- The label the client returns says the level again in words on some
+    -- builds: "(Loyalty Level 4) Dependable". The number is printed right
+    -- beside it, so a leading parenthetical is dropped - it said nothing new
+    -- and cost a line break in a window this narrow.
+    if type(text) == "string" then
+        text = string.gsub(text, "^%s*%b()%s*", "")
+        text = string.gsub(text, "^%s*(.-)%s*$", "%1")
+        if text == "" then text = nil end
+    end
+    return lvl, text
+end
+
+-- ------------------------------------------------------------
+function AP:Build()
+    if self.win then return self.win end
+    local f = CreateFrame("Frame", "Aegis_SBR_PetFrame", UIParent)
+    f:SetWidth(BASE_W); f:SetHeight(74)
+    -- Background only; the border below replaces the backdrop's own edge, which
+    -- would otherwise sit under the coloured bars as a second, thinner frame.
+    f:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        tile = true, tileSize = 16,
+        insets = { left = 0, right = 0, top = 0, bottom = 0 },
+    })
+    f:SetBackdropColor(COL_BG[1], COL_BG[2], COL_BG[3], COL_BG[4])
+
+    local function bar(p1, p2, w, h)
+        local t = f:CreateTexture(nil, "OVERLAY")
+        t:SetPoint(p1, f, p1, 0, 0)
+        t:SetPoint(p2, f, p2, 0, 0)
+        if w then t:SetWidth(w) end
+        if h then t:SetHeight(h) end
+        return t
+    end
+    f.border = {
+        bar("TOPLEFT", "TOPRIGHT", nil, BORDER_W),
+        bar("BOTTOMLEFT", "BOTTOMRIGHT", nil, BORDER_W),
+        bar("TOPLEFT", "BOTTOMLEFT", BORDER_W, nil),
+        bar("TOPRIGHT", "BOTTOMRIGHT", BORDER_W, nil),
+    }
+    f:SetFrameStrata("MEDIUM")
+    f:SetMovable(true); f:EnableMouse(true)
+    f:RegisterForDrag("LeftButton")
+    f:SetScript("OnDragStart", function() this:StartMoving() end)
+    f:SetScript("OnDragStop", function()
+        this:StopMovingOrSizing()
+        local db = AP:DB()
+        if db then
+            local point, _, relPoint, x, y = this:GetPoint()
+            db.pos = { point = point, relPoint = relPoint, x = x, y = y }
+        end
+    end)
+
+    local function line(y, font, col)
+        local t = f:CreateFontString(nil, "OVERLAY", font)
+        t:SetPoint("TOPLEFT", f, "TOPLEFT", BORDER_W + 6, y)
+        t:SetWidth(BASE_W - 20); t:SetJustifyH("LEFT")
+        t:SetTextColor(col[1], col[2], col[3])
+        return t
+    end
+
+    f.nameText  = line(-8,  "GameFontNormalSmall", COL_TEXT)
+    f.xpText    = line(-24, "GameFontNormalSmall", COL_MUTE)
+    f.happyText = line(-40, "GameFontNormalSmall", COL_TEXT)
+    f.loyalText = line(-56, "GameFontNormalSmall", COL_TEXT)
+
+    -- The level sits right-aligned on the name line, so a long pet name cannot
+    -- push it out of the window.
+    local lvl = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    lvl:SetPoint("TOPRIGHT", f, "TOPRIGHT", -(BORDER_W + 6), -8)
+    lvl:SetJustifyH("RIGHT")
+    lvl:SetTextColor(COL_TITLE[1], COL_TITLE[2], COL_TITLE[3])
+    f.levelText = lvl
+
+    local db = self:DB()
+    if db and db.scale then f:SetScale(db.scale) end
+    if db and db.pos then
+        f:SetPoint(db.pos.point or "CENTER", UIParent, db.pos.relPoint or "CENTER",
+                   db.pos.x or 0, db.pos.y or 0)
+    else
+        f:SetPoint("CENTER", UIParent, "CENTER", 0, -220)
+    end
+
+    f:SetScript("OnUpdate", function()
+        AP.elapsed = (AP.elapsed or 0) + (arg1 or 0)
+        if AP.elapsed < TICK then return end
+        AP.elapsed = 0
+        AP:Refresh()
+    end)
+
+    f:Hide()
+    self.win = f
+    return f
+end
+
+function AP:BorderColor(r, g, b, a)
+    local f = self.win
+    if not (f and f.border) then return end
+    for i = 1, table.getn(f.border) do
+        f.border[i]:SetTexture(r, g, b, a or 1)
+    end
+end
+
+function AP:Refresh()
+    local f = self.win
+    if not f or not f:IsShown() then return end
+
+    if not UnitExists("pet") or UnitIsDead("pet") then
+        f.nameText:SetText("no pet")
+        f.levelText:SetText("")
+        f.xpText:SetText("")
+        f.happyText:SetText("")
+        f.loyalText:SetText("")
+        self:BorderColor(0.30, 0.30, 0.33, 0.9)
+        return
+    end
+
+    f.nameText:SetText(UnitName("pet") or "pet")
+    f.levelText:SetText("Lv " .. (UnitLevel("pet") or "?"))
+
+    -- Experience is only reported for a pet that still gains it; a pet at the
+    -- player's level reads back as zero, and a blank line says that better than
+    -- "0 / 0" does.
+    local cur, max = 0, 0
+    if GetPetExperience then cur, max = GetPetExperience() end
+    if max and max > 0 then
+        f.xpText:SetText("XP " .. cur .. " / " .. max
+            .. "   " .. math.floor(cur / max * 100 + 0.5) .. "%")
+    else
+        f.xpText:SetText("")
+    end
+
+    -- One call, and NOT written as `GetPetHappiness and GetPetHappiness()`:
+    -- an `and` expression is truncated to a single value, so the damage figure
+    -- would silently come back nil.
+    local h, dmg
+    if GetPetHappiness then h, dmg = GetPetHappiness() end
+    local hap = h and HAPPY[h]
+    if hap then
+        self:BorderColor(hap.r, hap.g, hap.b, 1)
+        f.happyText:SetText(hap.label .. (dmg and ("   " .. dmg .. "% dmg") or ""))
+        f.happyText:SetTextColor(hap.r, hap.g, hap.b)
+
+    else
+        -- A warlock pet, or any pet without happiness.
+        self:BorderColor(0.30, 0.30, 0.33, 0.9)
+        f.happyText:SetText("")
+    end
+
+    local lvl, ltext = self:Loyalty()
+    if lvl then
+        f.loyalText:SetText("Loyalty " .. lvl .. (ltext and ("  " .. ltext) or ""))
+    else
+        f.loyalText:SetText("")
+    end
+end
+
+function AP:SetShown(on)
+    local db = self:DB()
+    if db then db.shown = on and true or false end
+    local f = self:Build()
+    if on then f:Show(); self:Refresh() else f:Hide() end
+end
+
+function AP:Toggle()
+    self:SetShown(not self:Enabled())
+    return self:Enabled()
+end
+
+function AP:Restore()
+    if self:Enabled() then self:SetShown(true) end
+end

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -30,7 +30,7 @@ local M = Aegis_SBR:NewClassModule("HUNTER")
 M.uiTitle = "Hunter"
 -- Rotate runs under Aegis_SBR:Preview without casting (see Pick/Later).
 M.previewReady = true
-M.uiHeight = 850
+M.uiHeight = 878
 M.meleeAutoAttack = false   -- managed here: Auto Shot (ranged) or Attack (melee)
 M.autoAcquireTarget = false -- a ranged class should not auto-pull random mobs; pick targets
 
@@ -378,6 +378,11 @@ function M:MaintainDebuff(name, interval)
     return true
 end
 
+-- Stings this client has actually been seen to read back off a target. Kept for
+-- the session, because it is a property of the CLIENT (SuperWoW name resolution,
+-- or an icon fragment that matches), not of any one mob.
+M.stingSeen = {}
+
 -- Sting upkeep. Identical bookkeeping to MaintainDebuff, but the stings are
 -- ranged-weapon shots, so they must go out through the Nampower shot queue
 -- (QueueSpellByName) exactly like Steady / Arcane / Multi-Shot. Dispatching a
@@ -386,11 +391,26 @@ end
 -- up, which silently burns the reapply throttle and the sting never fires.
 function M:MaintainSting(name, interval)
     if not self:KnowsSpell(name) then return false end
-    if self:TargetDebuffUp(name, STING_TEX[name]) then return false end
+    if self:TargetDebuffUp(name, STING_TEX[name]) then
+        self:Later(function() self.stingSeen[name] = true end)
+        return false
+    end
     local id = self:TargetId()
     local rec = self.debuffThrottle[name]
     local now = GetTime()
-    if rec and rec.id == id and rec.t and (now - rec.t) <= (interval or 3) then
+    -- How long to wait before trying again.
+    --
+    -- The sting's full duration is only the right answer on a client that cannot
+    -- read the sting back off the target - there the timer IS the whole
+    -- knowledge. Once it has been read once, the debuff check above is the
+    -- authority, and waiting fifteen more seconds after it reports "not up" is
+    -- simply wrong: a shot that missed or was resisted then goes un-reapplied for
+    -- the sting's entire duration. All that is still needed is the moment an
+    -- applied debuff takes to register, which is what STING_QUEUE_HOLD measures -
+    -- and it is the same beat the queue hold below already waits out.
+    local wait = interval or 3
+    if self.stingSeen[name] then wait = STING_QUEUE_HOLD end
+    if rec and rec.id == id and rec.t and (now - rec.t) <= wait then
         return false
     end
     if not self:Queue(name, "sting missing") then return false end
@@ -909,6 +929,10 @@ hunterFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 hunterFrame:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")  -- enemy attacks we avoided
 hunterFrame:RegisterEvent("CHAT_MSG_COMBAT_PET_HITS")                 -- our pet's damage
 hunterFrame:RegisterEvent("UNIT_CASTEVENT")                           -- SuperWoW: exact cast/shot timing
+-- A resisted, missed or immune shot of ours is reported here. Without it those
+-- look exactly like a sting that had just landed and not yet registered, so the
+-- reapply throttle sat on it for the sting's whole duration.
+hunterFrame:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 hunterFrame:SetScript("OnEvent", function()
     if event == "PLAYER_REGEN_ENABLED" then
         M.autoShotOn = false
@@ -921,6 +945,42 @@ hunterFrame:SetScript("OnEvent", function()
     elseif event == "CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES" then
         if arg1 and string.find(string.lower(arg1), "dodge") then
             M.dodgeUntil = GetTime() + REACT_WINDOW
+        end
+    elseif event == "CHAT_MSG_SPELL_SELF_DAMAGE" then
+        -- "Your Serpent Sting was resisted by X." / "... missed X." The throttle
+        -- exists to stop a second cast while the first is still registering on
+        -- the target; a resist or a miss means there is nothing to register, so
+        -- it is cleared and the next press re-applies immediately. Matching only
+        -- the word "resisted" was the bug: a MISS left the throttle standing and
+        -- the sting went unapplied for its full fifteen seconds.
+        --
+        -- Still deliberately narrow: only our own shots, named in the line.
+        local shot
+        if arg1 then
+            for name in pairs(STING_TEX) do
+                if string.find(arg1, name, 1, true) then shot = name; break end
+            end
+        end
+        if shot then
+            if string.find(arg1, "immune") then
+                -- "Your Serpent Sting failed. X is immune." Definitive, and
+                -- better than the 2.5s inference in StingBlocked, which only
+                -- dares to conclude immunity on an Undead. The throttle is left
+                -- alone on purpose: there is nothing to retry. Only when the line
+                -- names the CURRENT target, so a message about something else
+                -- cannot silence the sting on this one.
+                if shot ~= "Hunter's Mark" then
+                    local tname = UnitName("target")
+                    local _, guid = UnitExists("target")
+                    if guid and tname and string.find(arg1, tname, 1, true) then
+                        M.stingImmune[guid] = true
+                    end
+                end
+                M.stingTry = nil
+            elseif string.find(arg1, "resist") or string.find(arg1, "miss") then
+                M.debuffThrottle[shot] = nil
+                M.stingTry = nil
+            end
         end
     elseif event == "CHAT_MSG_COMBAT_PET_HITS" then
         if arg1 and string.find(string.lower(arg1), "crit") then

--- a/classes/Class_Hunter_UI.lua
+++ b/classes/Class_Hunter_UI.lua
@@ -60,6 +60,12 @@ function M:BuildBody(ui, parent)
     self.tauntRow = L:Row{ key = "petTaunt", label = "Pet taunt", spell = "Growl", onToggle = set("petTaunt") }
     self.kcRow = L:Row{ key = "useKillCommand", label = "Kill Command", spell = "Kill Command", onToggle = set("useKillCommand") }
     self.baitedRow = L:Row{ key = "useBaitedShot", label = "Baited Shot on pet crit", spell = "Baited Shot", onToggle = set("useBaitedShot") }
+    -- A window, not a rotation setting, so it writes to the pet module directly
+    -- and lives per character rather than per profile - the same arrangement the
+    -- rogue's poison rows use for the shared upkeep module.
+    self.petWinRow = L:Row{ key = "petWindow", label = "Show pet window", onToggle = function(on)
+        if Aegis_SBR_Pet then Aegis_SBR_Pet:SetShown(on) end
+    end }
 
     L:Header("Cooldowns")
     self.cdRow = L:Row{ key = "popCDs", label = "Pop cooldowns", onToggle = set("popCDs") }
@@ -88,6 +94,7 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.manaAspRow.slider, "Viper below", "Drop to Aspect of the Viper when your mana falls under this percent.")
     ui:Tip(self.manaBackRow.slider, "Back to combat at", "Swap back to Aspect of the Hawk/Wolf once mana recovers to this percent. Set it above the 'Viper below' value.")
     ui:Tip(self.petRow.cb, "Pet attack", "Sends your pet onto the target each press.")
+    ui:Tip(self.petWinRow.cb, "Show pet window", "A small movable readout: level, experience toward the next level, and happiness, with the border coloured green, yellow or red so the state reaches you across the screen.", "All of it is in the default Pet Details panel too - the point is a window small enough to leave up. There is deliberately no countdown to the next loyalty level: the client exposes no progress within a level, and a measured one restarted at every zone line, because a zone change dismisses the pet for a moment and that looks exactly like a new level starting.")
     ui:Tip(self.mendRow.cb, "Mend Pet", "Heals the pet below the slider value (HoT, refreshed ~12s).")
     ui:Tip(self.mendRow.slider, "Mend Pet below", "Pet health percent under which Mend Pet is cast.")
     ui:Tip(self.kcRow.cb, "Kill Command", "Beast Mastery: fired on cooldown while in combat.")
@@ -131,6 +138,7 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.aspectRow, buf.useAspect)
     ui:BindCheck(self.manaAspRow, buf.useManaAspect)
     ui:BindCheck(self.petRow, buf.petAttack)
+    if Aegis_SBR_Pet then self.petWinRow.cb:SetChecked(Aegis_SBR_Pet:Enabled()) end
     ui:BindCheck(self.tauntRow, buf.petTaunt)
     ui:BindCheck(self.mendRow, buf.useMendPet)
     ui:BindCheck(self.kcRow, buf.useKillCommand)

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -44,6 +44,18 @@ git worktree remove ../_wt-feature
 A worktree is a second checkout of the same repository in another directory. The
 dev folder keeps `local/integration` the whole time, so live stays valid.
 
+## A NEW file needs a client restart, not a reload
+
+`/reload` re-runs the files the client already has open. It does not re-read the
+`.toc`, so a file added since the client started - a new module, a new texture -
+simply is not there. The addon then behaves as if the work was never done:
+`Icons/Grip.tga` rendered as nothing, and `Aegis_SBR_Pet.lua` looked like a
+toggle that did not work.
+
+Editing an existing file is fine with `/reload`. Adding one is not. When a
+change introduces a file, say so and restart the client before concluding
+anything about whether it works.
+
 ## Never stack a PR on another PR's branch
 
 Every branch is cut from `origin/main`, without exception. Setting a PR's base to


### PR DESCRIPTION
## Pet window

A small movable readout — name, level, experience toward the next level, happiness — with the border coloured green / yellow / red. The border carries the happiness because that is the part you act on, and a colour reaches you across the screen where a number does not.

Toggled from the Hunter panel or `/sbr pet`; position and scale are remembered per character.

**Deliberately no countdown to the next loyalty level.** One was built and removed again: the client exposes no progress within a level, so it has to be measured — and a zone change dismisses the pet for a moment, which is indistinguishable from a level starting. The clock restarted at every zone line. The reasoning is in the code and in the tooltip so it does not get rebuilt.

## Serpent Sting: reapplied after a miss

The reapply throttle is set when the sting is queued and held for the sting's full duration. The combat-log handler that clears it matched only the word `resisted` — so a **miss** left the throttle standing and the sting went unapplied for fifteen seconds. That is the reported symptom: "der DoT wird nach einem Miss erst deutlich später erneut versucht."

- a miss now clears the throttle as well
- an explicit `... is immune` line is taken at its word (and only when it names the current target) instead of being inferred from a debuff that never appeared

## The throttle itself

On a client that can read the sting back off the target, `TargetDebuffUp` is the authority — waiting the sting's full duration *after* it reports "not up" is simply wrong. Once the sting has been read once (remembered per client, since it is a property of the client's debuff resolution and not of any mob), the wait drops to `STING_QUEUE_HOLD`, the beat an applied debuff takes to register — the same one the queue hold below already waits out. On a client that cannot read it, the blind duration timer stays exactly as before, and it learns which case it is in on its own.

This also covers the failures the combat log never reports.

## Testing

`scripts/verify.py --all` passes. The pet window was played with on a live hunter: happiness colour, level and XP confirmed, loyalty line trimmed to fit after the client turned out to return `(Loyalty Level 4) Dependable`.

The sting change is measured but not yet played — worth a look at whether the sting now reapplies promptly on a resisted or missed shot.

Note for testers: `Aegis_SBR_Pet.lua` is a **new file**, so it needs a full client restart, not `/reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
