### PR TITLE
Shaman: Totemic Recall no longer needs the client to still see the totem

### DIFF
--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -846,9 +846,30 @@ function M:RecallDue(cfg)
     for i = 1, table.getn(TOTEM_SLOTS) do
         local slot = TOTEM_SLOTS[i]
         local guid = self.totemGuid[slot]
-        if guid and UnitExists(guid) then
+        local live = (guid and UnitExists(guid)) and true or false
+        -- ClassicAPI reads the element slot from the client's own totem tracker,
+        -- which does NOT need the totem's object to be loaded. That fixes the
+        -- exact case this feature exists for: walk far enough away and the client
+        -- drops the distant object, so UnitExists(guid) goes false, the totem
+        -- stops counting as standing, and the recall can never fire. Reported
+        -- from play as "recall only works with a mob targeted" - with a target
+        -- you are usually still close enough for the object to be loaded.
+        local capiName = self:CapiTotem(slot)
+
+        if live or capiName then
             standing = standing + 1
-            if self:TotemOutOfRange(slot) and not self:GroupNearTotem(guid, self:TotemRadius(slot)) then
+            if live then
+                -- Object loaded: measure properly, and leave it alone if a group
+                -- member is still standing in its radius.
+                if self:TotemOutOfRange(slot) and not self:GroupNearTotem(guid, self:TotemRadius(slot)) then
+                    stranded = stranded + 1
+                end
+            else
+                -- The slot says a totem stands but the client has no object for
+                -- it. A totem cannot move, so losing its object IS the distance
+                -- evidence. The group check is skipped here because it needs a
+                -- position - accepted, because a totem too far for the shaman's
+                -- own client to keep loaded is not one the party is still using.
                 stranded = stranded + 1
             end
         end


### PR DESCRIPTION
Reported from play: recall only fired while a mob was targeted, and it is needed precisely when there is no mob left.

## Targeting was never the condition

`RunsWithoutTarget` already lets a targetless press reach the recall, and documents that intent in its own comment. The real gate sat inside `RecallDue`:

```lua
if guid and UnitExists(guid) then
    standing = standing + 1
```

A totem only counted as standing while `UnitExists(guid)` was true — which needs the client to still have its **object** loaded. Walk far enough away, which is exactly when you want to recall, and the distant object is dropped: `standing` falls to 0 and the "every standing totem is stranded" test can never pass.

With a mob targeted you are usually still close enough for the object to survive. That is why it looked like a targeting condition.

## Fix

`RecallDue` now also accepts ClassicAPI's element-slot read, which comes from the client's own totem tracker and needs no object.

| Case | Behaviour |
|---|---|
| Object loaded | Unchanged — distance measured properly, and a group member standing in the totem's radius still protects it |
| Object dropped, slot says a totem stands | Counts as stranded: a totem cannot move, so losing its object **is** the distance evidence |

The group check is skipped in the second branch because it needs a position. Accepted deliberately: a totem too far for the shaman's own client to keep loaded is not one the party is still standing in.

**Without ClassicAPI the behaviour is unchanged**, including the limitation — there is no object-independent way to see the slot on a stock 1.12 client.

## Verification

- `python3 scripts/verify.py --all` passes; Lua syntax parsed.
- **Confirmed in play** by the reporter: totems down, walked well away with no target selected, press — recall fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

