### PR TITLE
docs: salvage the unmerged Phase 0 resync, corrected to v1.1.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,11 @@ calculators block automated access.
     `(arg or "") == "on"` — that idiom sends every unrecognised argument, the empty one
     included, to `false`, so a bare command silently disables what it was meant to toggle
     (fixed v1.1.5 in three places). Test its result with `== nil`; `false` is a valid return.
+  - `GetWeaponEnchantInfo` returns **six** values on 1.12, not seven — an assumed extra
+    return shifted `hasOffHand` onto the off-hand *expiration*, so the off-hand reading was
+    silently wrong. Latent from v0.15.0 until v1.1.8 because only the main hand had a
+    caller. When a 1.12 API's return count is assumed rather than counted, check it against
+    a live call before building on the later values.
   - A second detection source (ClassicAPI) wired into a gate may only ever **suppress** a
     cast, never shorten a throttle or unblock one. Letting it shorten the sting retry while
     the OLD detection still decided whether to cast re-queued a ranged shot every 1.5s and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,22 @@ the `AegisUI_*` prefix.)
 - Casting primitives: `Cast(name)` (reports success if merely KNOWN — see the caveat in the
   Warrior module header), `Queue(name)` (uses Nampower queueing), `Try(name)` /
   `CanCast(name, cost, stances)` wrappers in some modules.
+- Shared resource/timing helpers (core, v1.1.8+): `Aegis_SBR:SpellCost(name)` /
+  `CanAfford(name)` read a spell's real cost off the spellbook **tooltip** (cached, dropped
+  on `SPELLS_CHANGED`/`CHARACTER_POINTS_CHANGED`) instead of a hardcoded table, so a talent
+  that shifts a cost is never fought — prefer this over a new per-class rage/energy/mana
+  table. `Aegis_SBR:TargetTTK()` estimates seconds-to-kill from a rolling window of the
+  target's health percent; it returns `nil` (never a guess) until it has enough samples,
+  and every caller must treat `nil` as "not dying soon" — it is accurate enough to **veto**
+  an action, not to **trigger** one (see the Rogue execute logic for the failure mode when
+  that line was crossed: TTK briefly triggered execute and fired it on a single combo point
+  against ordinary trash, since a normal mob's whole life is shorter than any sane window).
+  `Aegis_SBR:SpellRadius(name)` and `Aegis_SBR:SpellDuration(name)` (v1.1.9) read the same
+  way and for the same reason — both numbers are **rank dependent**, so a hardcoded table is
+  wrong for every rank but one. `SpellDuration` exists because rank 1 *Searing Totem* lasts
+  30s where the shaman's table said 55, leaving a levelling shaman's fire slot empty for 25
+  seconds. Both return `nil` when the tooltip cannot be read, and callers keep their own
+  fallback: these correct a number, they do not replace the caller's judgement.
 - Heal engines: four near-identical copies live in the healer modules
   (Paladin/Priest/Druid/Shaman) — slated for dedupe (roadmap Phase 2). Touch with care;
   changing one usually means changing all four until deduped.

--- a/docs/audit-phase1-rotations.md
+++ b/docs/audit-phase1-rotations.md
@@ -137,8 +137,16 @@ taunt when the target isn't on you → Stormstrike → shock (Earth default) →
 → totems → optional LB. **Restoration**: Mana Tide ≤25% mana → NS-equivalent → instant
 max-rank Healing Wave (emergency ≤40%) → Lesser Healing Wave (≤50%, beats AoE) → Chain Heal
 (≥3 hurt) → downranked Healing Wave → Water Shield → totems → optional LB damage weave.
-Totem clocks are stamped by SuperWoW `UNIT_CASTEVENT` (manual drops reset the right slot)
-with 55s water / 110s other redrop timers.
+
+> **Updated past Phase 1 (v1.1.7 and v1.1.9, not re-audited — noted here so this section
+> stays accurate as a baseline):** totem upkeep no longer runs on the blind 55s/110s clocks
+> described below. v1.1.7 replaced them with the totem's own player-granted aura where one
+> exists, plus per-totem intervals for those that grant none. v1.1.9 reads the element slot
+> directly through ClassicAPI where it is installed, which also covers the aura-less totems
+> and detects a totem **destroyed** rather than expired; the intervals themselves now come
+> from the spell tooltip, because they are rank dependent. Players without ClassicAPI still
+> run the v1.1.7 path. See `docs/roadmap.md` Phase 2 for the detail. The rest of this
+> section (S1-S9) is unchanged and still reflects the current code.
 
 ### Discrepancies
 
@@ -166,9 +174,11 @@ with 55s water / 110s other redrop timers.
   Water Shield → totems) matches the `[V]` sketch; rank tables are flagged in-code as
   vanilla baselines pending the Phase 3 live tuning — consistent with research's own
   "needs `[?]` tuning".
-- The cross-spec totem system with `UNIT_CASTEVENT` stamping is beyond research; Phase 2
-  adds destruction detection. Redrop intervals (55s/110s) are already flagged in-code for
-  Turtle-duration tuning. ✓
+- The cross-spec totem system is beyond research; Phase 2's destruction-detection item is
+  DONE — v1.1.7's aura-read covered the totems that grant one, v1.1.9's ClassicAPI slot read
+  and `PLAYER_TOTEM_UPDATE` closed the aura-less gap and were verified in play. Redrop
+  intervals are no longer vanilla baselines: they are read from the spell tooltip, which is
+  rank- and server-correct by construction. ✓
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,21 +152,58 @@ from the polish backlog if built.
 
 ## Phase 2 — Engine robustness & code health
 
-- **Shaman totem destruction detection**: tag totem GUIDs on cast (SuperWoW) and watch the
-  combat log's owner-tagging for a totem dying, then re-drop — instead of relying only on
-  expiry timers.
+- **Shaman totem destruction detection.**
+  > **STATUS: DONE and verified in v1.1.9.** It took two goes, and neither used the
+  > GUID-plus-combat-log watch planned here.
+  >
+  > **v1.1.7** made totem upkeep read the **player's own aura** where the totem grants one
+  > (`Class_Shaman.lua`, `MaintainTotem`) — one check answering expiry, destruction, Totemic
+  > Recall and walking out of range at once. A totem name was trusted only once its aura had
+  > actually been *seen* after a cast, so a wrong entry in the name table degraded to the
+  > timer instead of spamming the slot. The same release replaced the two blanket redrop
+  > constants (55s water / 110s everything else) with **per-totem** intervals, because the
+  > blanket number was sized for 120s totems and left short ones missing for most of their
+  > cycle. **The gap:** totems that grant no aura at all — Searing, Magma, Fire Nova,
+  > Grounding — had nothing to read and still ran on a clock, which is exactly the set the
+  > clock serves worst.
+  >
+  > **v1.1.9** closed that gap with ClassicAPI: `GetTotemInfo` reads the element slot
+  > directly (no aura, no name guessing, no clock) and `PLAYER_TOTEM_UPDATE` fires on a
+  > totem **killed or recalled** rather than expired. Verified in play — Totemic Recall
+  > emptied two slots in the same instant and both were re-dropped 0.11s and 0.34s later.
+  > Two further fixes fell out of it: the per-totem intervals were still max-rank values
+  > (rank 1 Searing lasts 30s, the table said 55), now read from the spell tooltip via
+  > `Aegis_SBR:SpellDuration`; and a totem on cooldown was retried every 1.5s through its
+  > dead window. Both of those help players **without** ClassicAPI, who still run the
+  > v1.1.7 aura-and-clock path.
+  >
+  > Totem aura **names remain vanilla baselines** and want confirming on Turtle via
+  > `/sbr debug` — they still matter on the no-ClassicAPI path. See
+  > `docs/audit-phase1-rotations.md` item S9.
 - **Heal-engine dedupe**: unify the four near-identical heal engines
   (Paladin/Priest/Druid/Shaman) into one shared module; class modules pass config in.
+  **Still open** — untouched as of v1.1.9.
 - **Weapon-enchant awareness / poison + imbue upkeep** (Rogue + Shaman; per-class UI toggle):
   detect and optionally maintain weapon imbues (Shaman) and poisons (Rogue). **Full feasibility
   study in `docs/research-weapon-enchant-upkeep.md` — read it first.**
-  > **STATUS: first cut SHIPPED in v0.15.0** — shared detection helper
-  > (`Aegis_SBR:WeaponEnchant`/`WeaponEnchantId`), Shaman main-hand imbue upkeep
-  > (out-of-combat auto-apply + in-combat opt-in, default OFF), Rogue poison pre-pull
-  > reminder (warn-only). **Still open:** off-hand imbue; Rogue poison auto-apply (needs the
-  > replace-popup + in-combat-application dummy tests, items 3 & 4 in the research doc); and
-  > topping-up an imbue that's present-but-low via overwrite (blocked on the popup test —
-  > currently warn-only).
+  > **STATUS: first cut SHIPPED in v0.15.0**, substantially extended in v1.1.7/v1.1.8.
+  > Shaman imbue upkeep now runs in **every spec** (Restoration and Elemental included, not
+  > just Enhancement/Tank) as two independent, either-alone routes: automatic
+  > (out-of-combat auto-apply, in-combat opt-in, default OFF) and a manual clickable rebuff
+  > button ported from BuffUp's item-slot-watch mode to its spell-slot-watch mode (v1.1.7).
+  > The two Rogue poison buttons gained a low-charge warning state (≤5 charges: yellow,
+  > blinking, shows the count) so the prompt appears **before** the poison is gone, not only
+  > after (v1.1.8) — still a pre-pull-style reminder, not mid-fight automation. Found and
+  > fixed alongside it: `Aegis_SBR:WeaponEnchant`'s off-hand reading was landing on the
+  > wrong field (`GetWeaponEnchantInfo` returns **six** values on 1.12, not seven — a stray
+  > extra return shifted `hasOH` onto the off-hand expiration), latent until v1.1.8 because
+  > only the main hand had ever been wired to a caller.
+  > **Still open:** off-hand imbue is explicitly deferred, not attempted-and-blocked — the
+  > in-code comment calls it "a fragile weapon-click flow"; Rogue poison auto-apply beyond
+  > the click-driven Quick Bar/warning button (needs the replace-popup + in-combat-
+  > application dummy tests, items 3 & 4 in the research doc); and topping up an
+  > imbue that's present-but-low via overwrite (blocked on the popup test — currently
+  > warn-only).
 
   Key findings:
   - **Primary API is `GetWeaponEnchantInfo()`** (returns `has*`, **`*Expiration` in ms**,


### PR DESCRIPTION
Commit `447243e` sat unmerged on `claude/aegis-sbr-rebrand-phase-0-ua55yk`: a docs resync from 2026-08-12 that never landed. Deleting that branch would have discarded the only written record of several v1.1.7/v1.1.8 decisions — so this rescues it, **corrected** where v1.1.9 has since moved the ground.

## Taken as written

- **`architecture.md`'s shared-helper section** — `SpellCost`/`CanAfford` reading the spellbook tooltip instead of a hardcoded table, and `TargetTTK` returning `nil` rather than a guess, with the rule that it is accurate enough to **veto** an action and not to **trigger** one. (The Rogue execute logic is the recorded failure mode from crossing that line.)
- **The weapon-enchant / poison status block**, including the six-vs-seven return values of `GetWeaponEnchantInfo`.

Extended: `SpellRadius` / `SpellDuration` now sit in the same paragraph — same idea, arrived in v1.1.9 for the same reason (the numbers are rank dependent, so a table is wrong for every rank but one).

## Rewritten, not restored

The totem entry claimed destruction detection was **DONE in v1.1.7** via the aura read. That covered only totems that *grant* an aura — Searing, Magma, Fire Nova and Grounding had nothing to read and still ran on a clock, which is exactly the set a clock serves worst.

The item actually closed in **v1.1.9**, with ClassicAPI's slot read plus `PLAYER_TOTEM_UPDATE`, verified in play. The same entry also called the per-totem intervals "vanilla baselines"; they are now read from the tooltip. The audit report's baseline note carried the identical claim and is corrected too.

Restoring that text unchanged would have put a confident, wrong status into the two documents a future session reads first.

## Dropped

- The version bump — superseded, `main` is at 1.1.9.
- The `CLAUDE.md` Current State rewrite — superseded by the v1.1.9 one already in `main`.

One thing was lifted out of it: the `GetWeaponEnchantInfo` return-count bug is a bug **class**, so house style puts it in the Lessons list rather than leaving it in roadmap prose where nobody looks before writing API code.

## After this

`origin/claude/aegis-sbr-rebrand-phase-0-ua55yk` can be deleted — this is everything on it that still had value.

Docs only; no code paths touched. `python3 scripts/verify.py --all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
