### PR TITLE
Hunter: learn sting immunity per creature type, not per corpse

### DIFF
--- a/Aegis_SBR_Capabilities.lua
+++ b/Aegis_SBR_Capabilities.lua
@@ -30,6 +30,7 @@ local caps = {
     range    = false,   -- C_Spell.IsSpellInRange: true geometric range
     cooldown = false,   -- C_Spell.GetSpellCooldown by spell id
     totems   = false,   -- GetTotemInfo + PLAYER_TOTEM_UPDATE
+    creature = false,   -- UnitCreatureID: the creature-template id behind a unit
     loc      = false,   -- C_LossOfControl: stun / silence / school lockout
     timer    = false,   -- C_Timer.After
     encoding = false,   -- C_EncodingUtil: profile import/export (roadmap P3)
@@ -53,6 +54,7 @@ function Aegis_SBR:DetectClassicAPI()
         caps.range    = (C_Spell and C_Spell.IsSpellInRange) and true or false
         caps.cooldown = (C_Spell and C_Spell.GetSpellCooldown) and true or false
         caps.totems   = (GetTotemInfo ~= nil)
+        caps.creature = (UnitCreatureID ~= nil)
         caps.loc      = (C_LossOfControl
                          and C_LossOfControl.GetActiveLossOfControlDataCount
                          and C_LossOfControl.GetActiveLossOfControlData) and true or false
@@ -233,6 +235,28 @@ function Aegis_SBR:TotemRemaining(name)
 end
 
 -- ============================================================
+-- Creature identity
+-- ============================================================
+-- The creature-TEMPLATE id: every Kobold Geomancer in the world shares one, and
+-- it is stable across sessions. That is the difference between learning
+-- something about the mob in front of you and learning it about the KIND of mob
+-- - a lesson worth keeping is worth keeping past this one corpse.
+--
+-- Vanilla packs the entry id into bits 24-47 of a creature GUID, so this is a
+-- read, not a cache lookup. nil for players (a player GUID carries no template),
+-- for an empty token, and when ClassicAPI is absent.
+function Aegis_SBR:UnitCreatureID(unit)
+    if not self:Capability("creature") then return nil end
+    unit = unit or "target"
+    if not UnitExists(unit) then return nil end
+    -- pcall'd: a garbage token raises, and this is called from rotation gates
+    -- where an error would take the whole press down.
+    local ok, id = pcall(UnitCreatureID, unit)
+    if ok and type(id) == "number" and id > 0 then return id end
+    return nil
+end
+
+-- ============================================================
 -- Loss of control
 -- ============================================================
 -- Returns seconds remaining for the first active effect of locType, or nil.
@@ -279,6 +303,7 @@ local CAP_ORDER = {
     { "range",    "exact spell range (incl. min range)" },
     { "cooldown", "spell cooldown by id" },
     { "totems",   "totem tracking + destruction" },
+    { "creature", "creature-template id (per mob type, not per mob)" },
     { "loc",      "stun / silence / school lockout" },
     { "timer",    "deferred callbacks" },
     { "encoding", "profile import/export" },

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -504,11 +504,58 @@ M.STING_IMMUNE_TYPES = { Mechanical = true, Elemental = true }
 M.stingImmune = {}   -- [targetGUID] = true, learned for the current combat
 M.stingTry = nil     -- { guid, t, name }: a sting application waiting to confirm
 
+-- Immunity learned per creature TEMPLATE, kept across sessions in AegisDB.
+--
+-- The GUID table above forgets everything when combat ends, which means the same
+-- lesson is re-bought with a wasted sting on the next Baron Aquanis, and the one
+-- after that. Immunity is a property of the KIND of mob, not of the corpse in
+-- front of you, so with ClassicAPI's creature-template id it is worth keeping.
+--
+-- Deliberately still opt-in on evidence, not on a hardcoded list: the same
+-- single-cast proof as before decides, this only changes how long the answer is
+-- remembered. Types that are ALWAYS immune (Mechanical/Elemental) stay a type
+-- check and never enter this table.
+local IMMUNE_MEMORY_MAX = 200
+
+function M:ImmuneMemory()
+    if not AegisDB then return nil end
+    if type(AegisDB.stingImmuneIDs) ~= "table" then AegisDB.stingImmuneIDs = {} end
+    return AegisDB.stingImmuneIDs
+end
+
+function M:RememberImmune(id)
+    if not id then return end
+    local mem = self:ImmuneMemory()
+    if not mem then return end
+    if mem[id] then return end
+    -- Bounded so a long-lived profile cannot grow this without limit. Immune
+    -- mobs are rare enough that hitting the cap means something is wrong, so it
+    -- is cleared wholesale rather than pruned cleverly - relearning costs one
+    -- sting per type, which is exactly what this feature already accepts.
+    local n = 0
+    for _ in pairs(mem) do n = n + 1 end
+    if n >= IMMUNE_MEMORY_MAX then
+        AegisDB.stingImmuneIDs = {}
+        mem = AegisDB.stingImmuneIDs
+    end
+    mem[id] = true
+end
+
+function M:KnownImmuneType()
+    local id = Aegis_SBR.UnitCreatureID and Aegis_SBR:UnitCreatureID("target")
+    if not id then return false end
+    local mem = self:ImmuneMemory()
+    return (mem and mem[id]) and true or false
+end
+
 -- Read-only: is a sting blocked on the current target right now? No side effects
 -- (used by the rotation gate and the trace line).
 function M:StingImmuneNow()
     local ct = UnitCreatureType and UnitCreatureType("target")
     if ct and self.STING_IMMUNE_TYPES[ct] then return true end
+    -- Learned per mob type first: it survives the fight, so this is the check
+    -- that saves the wasted cast on every later specimen.
+    if self:KnownImmuneType() then return true end
     local _, guid = UnitExists("target")
     return (guid and self.stingImmune[guid]) and true or false
 end
@@ -532,6 +579,9 @@ function M:StingBlocked(sting)
             self.stingTry = nil
             if ct == "Undead" then
                 self.stingImmune[guid] = true     -- genuinely immune undead
+                -- and remember the TYPE, so the next one costs nothing
+                self:RememberImmune(Aegis_SBR.UnitCreatureID
+                    and Aegis_SBR:UnitCreatureID("target"))
                 return true
             end
         end
@@ -1011,7 +1061,9 @@ hunterFrame:SetScript("OnEvent", function()
         M.autoShotTarget = nil
         M.steadyT = 0
         M.lastAutoShot = 0   -- forget the ranged-swing phase between pulls
-        M.stingImmune = {}   -- relearn sting immunity each combat
+        -- Only the per-GUID half: what was learned per creature TYPE lives in
+        -- AegisDB and is meant to outlast the fight.
+        M.stingImmune = {}
         M.stingTry = nil
         M.stingQueuedT = nil
     elseif event == "CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES" then
@@ -1046,6 +1098,8 @@ hunterFrame:SetScript("OnEvent", function()
                     local _, guid = UnitExists("target")
                     if guid and tname and string.find(arg1, tname, 1, true) then
                         M.stingImmune[guid] = true
+                        M:RememberImmune(Aegis_SBR.UnitCreatureID
+                            and Aegis_SBR:UnitCreatureID("target"))
                     end
                 end
                 M.stingTry = nil


### PR DESCRIPTION
The updated ClassicAPI adds **`UnitCreatureID`** — the creature-**template** id behind a unit. Every Baron Aquanis shares one, and it is stable across sessions.

## The problem

Sting immunity was learned per target GUID and thrown away when combat ended:

```lua
M.stingImmune = {}   -- [targetGUID] = true, learned for the current combat
```

So the same lesson was re-bought with a wasted sting on the next specimen, and the one after that. Immunity is a property of the **kind** of mob, not of the corpse in front of you.

## What changed

Learned immunity is now stored by template id in `AegisDB` and survives the session.

**How immunity is concluded is unchanged**: the same single-cast proof, and still only on Undead — Mechanical and Elemental are already hard-blocked by type, and on anything else a missing debuff means the scan cannot read it rather than that the mob is immune. This only changes how long the answer is kept.

The per-GUID table stays as the fallback for clients without ClassicAPI, and is still cleared on leaving combat — it is the transient half. Both learning sites write to both.

Bounded at 200 entries, cleared wholesale on overflow rather than pruned: genuinely immune mobs are rare enough that reaching the cap means something is wrong, and relearning costs one sting per type, which is the price this feature already accepts.

## Structure

The wrapper lives in `Aegis_SBR_Capabilities.lua` behind a new `creature` capability, per the `C_*` rule in `CLAUDE.md`. It is `pcall`'d because it is read from a rotation gate, where an error would take the whole press down. `/sbr capi` lists it.

## Verification

- `python3 scripts/verify.py --all` passes; Lua syntax parsed for all files.
- Without ClassicAPI: `Capability("creature")` is false, the wrapper returns `nil`, and behaviour is exactly the previous per-GUID path.
- **Not yet play-tested.** Needs a hunter against a known poison-immune Undead — sting once, kill it, pull a second of the same type, and confirm no sting is spent on it. `/sbr trace` shows `(immune)` in the `sting=` field.

## Also reviewed, not taken

The updated API adds 27 functions, removes none, and changes no events, unit tokens or aura-filter semantics — so nothing needed fixing. Of the rest: nine are override-binding calls (no use for a macro-driven rotation), `GetTrackingInfo`/`SetTracking` would be unrequested automation, and `C_UnitAuras.UnitAura`/`UnitBuff`/`UnitDebuff` are positional retail forms we have no reason to switch to since `GetUnitAuras` suits the snapshot better. `fontstring:GetStringHeight` and the icon-aware `GetStringWidth` are worth having for UI sizing later — the Preview window currently hand-measures because it could not trust auto-sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
