### PR TITLE
Adopt the local/integration workflow this file has been asking for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ others, and with crits removed the ordering reverses. **13–19 casts per settin
 this**; roughly 100 would, or a log field recording what each cast would have healed without the
 crit. Do not change the default on the strength of the numbers currently in hand.
 
+**The dev folder is on `local/integration` and stays there (since 2026-09-01).** Never
+`git checkout` in it — that is what silently reverts files belonging to other branches, and the
+live folder is fed only from this copy. To build a PR, use a throwaway worktree off
+`origin/main`; to add to an open PR, a worktree on its existing branch. Both recipes are in
+`docs/dev-workflow.md`, which is worth reading before the first commit of a session.
+
 **Standing check, not a snapshot:** merged branches keep accumulating on the remote because
 deletion needs the user (it is refused from this sandbox). Run
 

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -13,23 +13,17 @@
 Verified changes are copied dev → live without asking. The live folder is not a
 git repo; it is a plain mirror.
 
-## ⚠️ Status (checked 2026-09-01): this is NOT the workflow in use
+## Status: in use since 2026-09-01
 
-`local/integration` **does not exist**. The dev folder sits on whichever feature branch is
-current, and each release has gone `git stash` → `checkout main` → `pull` → `checkout -b` →
-`stash pop`.
+For a long while it was not. `local/integration` did not exist, and every release went
+`git stash` → `checkout main` → `pull` → `checkout -b` → `stash pop` — the branch switching this
+file exists to prevent. It survived only because **one feature was in flight at a time**, where
+stash/pop happens to carry the whole working copy across. It still cost something adjacent:
+twice the live folder ended up missing already-merged work, because the dev copy is the only
+source live is fed from and a branch switch is exactly the moment it is not "everything current".
 
-That has been safe so far only because **one feature has been in flight at a time**: with a
-single branch, stash/pop carries the whole working copy across and nothing is silently reverted.
-The failure this file describes needs two or more branches in flight, which has not happened yet.
-
-It has still cost something adjacent. Twice the live folder ended up missing work that was
-already merged (a friend's `CLAUDE.md` and `docs/architecture.md`), because the dev copy is the
-only source live is fed from and a branch switch is exactly when that copy is momentarily not
-"everything current".
-
-**Decide before the next parallel feature**, and either adopt the rule below or replace it — a
-rule nobody follows is worse than no rule, because it is read as a description of reality.
+The branch now exists and the dev folder sits on it. **If you find yourself typing `git checkout`
+in the dev folder, stop** — that is the thing this document is for.
 
 ## The rule that makes this safe
 
@@ -52,15 +46,37 @@ Work and commit on `local/integration` as usual. To turn a commit into a clean
 PR branch off `main`, use a throwaway worktree instead of switching branch:
 
 ```bash
-git worktree add ../_wt-feature -b feature/<name> main
+git fetch origin
+git worktree add ../_wt-feature -b feature/<name> origin/main
 git -C ../_wt-feature cherry-pick <sha>          # or several
 git -C ../_wt-feature push -u origin feature/<name>
 gh pr create --base main --head feature/<name> --title "..." --body "..."
 git worktree remove ../_wt-feature
+git branch -D feature/<name>                     # the local ref the worktree left behind
 ```
 
-A worktree is a second checkout of the same repository in another directory. The
-dev folder keeps `local/integration` the whole time, so live stays valid.
+Branch off **`origin/main`**, not the local `main`: the local one is only as fresh as the last
+`fetch`, and a PR based on a stale main is how a merge picks up conflicts that were never real.
+
+A worktree is a second checkout of the same repository in another directory. The dev folder
+keeps `local/integration` the whole time, so live stays valid.
+
+## Adding a commit to a PR that is already open
+
+Same idea, checking out the existing remote branch instead of creating one:
+
+```bash
+git fetch origin
+git worktree add ../_wt-feature feature/<name>   # tracks origin/feature/<name>
+git -C ../_wt-feature cherry-pick <sha>
+git -C ../_wt-feature push
+git worktree remove ../_wt-feature
+```
+
+Do this rather than opening a second PR whenever the new work touches the same files or the same
+version number — two PRs that both edit `CHANGELOG.md` and the `.toc` will conflict, and both
+will want the same version. See "Never stack a PR on another PR's branch" below for the case
+where a second PR *is* right.
 
 ## A NEW file needs a client restart, not a reload
 


### PR DESCRIPTION
`docs/dev-workflow.md` has described a workflow that was never in use. The rule it opens with — *"the dev folder stays on `local/integration` and never changes branch"* — rested on a branch that **did not exist**. Every release instead went `stash` → `checkout main` → `pull` → `checkout -b` → `stash pop`, which is precisely the branch switching the file exists to prevent.

It survived on luck: with **one feature in flight at a time**, stash/pop happens to carry the whole working copy across, and the failure described needs two. It still cost something adjacent — twice the live folder ended up missing already-merged work, because the dev copy is the only source live is fed from and a branch switch is exactly the moment it is not "everything current".

The branch now exists and the dev folder sits on it permanently.

## Two corrections made while adopting the recipes

- **Branch off `origin/main`, not the local `main`.** The local one is only as fresh as the last `fetch`, and a PR based on a stale main invents conflicts that were never real.
- **The worktree leaves a local branch ref behind**, which wants deleting after `worktree remove`.

## One case the file did not cover

**Adding a commit to a PR that is already open** — a worktree on the existing remote branch rather than a second PR. This is the right move whenever the new work touches the same files or the same version number: two PRs both editing `CHANGELOG.md` and the `.toc` will conflict, and both will want the same version. That situation has come up three times in recent sessions and was resolved correctly each time by instinct; now it is written down, next to the existing note on when a second PR *is* right.

## Note

This PR is itself the first pass through the new workflow — commit on `local/integration`, cherry-pick into a throwaway worktree off `origin/main`. It exists separately only because #62 merged in the seconds between the push and the merge.

Docs only; no addon code touched, so no version cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
