### PR TITLE
v1.2.10 — A press spent on a cast that never happened

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.9",
+    ver = "1.2.10",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,
@@ -1432,12 +1432,29 @@ end
 
 -- Compared against the client's own strings, so it holds in any locale. The
 -- literals are only a fallback for a client that does not define them.
+-- Refusals that say something about the UNIT: it cannot be reached from here.
+-- These mark the unit as well as the spell.
 local CAST_REFUSED = {
     SPELL_FAILED_LINE_OF_SIGHT or "Target not in line of sight",
     SPELL_FAILED_OUT_OF_RANGE or "Out of range",
     SPELL_FAILED_TOO_CLOSE or "Target too close",
     SPELL_FAILED_UNIT_NOT_INFRONT or "Target needs to be in front of you",
     SPELL_FAILED_MOVING or "Can't do that while moving",
+}
+
+-- Refusals that say something about US, not about the target. These clear the
+-- SPELL's throttle and nothing else - blacklisting a unit because we were out of
+-- mana would stop us healing somebody who is perfectly reachable.
+--
+-- Mana matters here because a throttle stamped on a cast that never left is the
+-- worst of both worlds: Hunter's Mark carries a 110 second one, so a single
+-- unaffordable attempt used to leave the target unmarked for most of two minutes
+-- - and the sting, gated on the mark, never went out either.
+local CAST_REFUSED_SELF = {
+    ERR_NOT_ENOUGH_MANA or "Not enough mana",
+    SPELL_FAILED_NO_POWER or "Not enough mana",
+    ERR_OUT_OF_RAGE or "Not enough rage",
+    ERR_OUT_OF_ENERGY or "Not enough energy",
 }
 
 -- Spells the client has just refused, by name, with the time it said so.
@@ -1470,11 +1487,16 @@ end
 
 function Aegis_SBR:OnCastError(msg)
     if not msg then return end
-    local refused = false
+    local unitRefused, selfRefused = false, false
     for i = 1, table.getn(CAST_REFUSED) do
-        if msg == CAST_REFUSED[i] then refused = true; break end
+        if msg == CAST_REFUSED[i] then unitRefused = true; break end
     end
-    if not refused then return end
+    if not unitRefused then
+        for i = 1, table.getn(CAST_REFUSED_SELF) do
+            if msg == CAST_REFUSED_SELF[i] then selfRefused = true; break end
+        end
+    end
+    if not (unitRefused or selfRefused) then return end
     local now = GetTime()
 
     -- The spell, for the throttles that must not treat a thrown-away cast as a
@@ -1484,8 +1506,9 @@ function Aegis_SBR:OnCastError(msg)
         self.lastSpell = nil
     end
 
-    -- The unit, for the heal target selection.
-    if self.lastUnitCast and (now - (self.lastUnitCastAt or 0)) <= BLAME_WINDOW then
+    -- The unit, for the heal target selection. Only for refusals that are ABOUT
+    -- the unit.
+    if unitRefused and self.lastUnitCast and (now - (self.lastUnitCastAt or 0)) <= BLAME_WINDOW then
         self.castBlocked[self.lastUnitCast] = now
         -- Spent: one refusal marks one unit, so the next error cannot be blamed
         -- on the same cast.

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.9
+## Version: 1.2.10
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.10 — A press spent on a cast that never happened
+
+Two hunter reports, both about switching target while holding the macro down, and both landing
+on the same sentence: **`Pick` reports success on "known and learned", not on "accepted".**
+
+### 🐛 Fixed — Hunter's Mark and the sting missing after a target switch
+
+The cause has been written down in this file for months, in the comment on `MaintainSting`:
+
+> *"Dispatching a sting through the instant `CastSpellByName` path (**as MaintainDebuff does**)
+> lets Nampower drop it whenever a global cooldown is up, which silently burns the reapply
+> throttle and the sting never fires."*
+
+The sting was moved to the queue when that was written. **Hunter's Mark was left on the path the
+comment names as broken.**
+
+Which is exactly what a target switch under a held macro produces: the press lands mid-global-
+cooldown from the cast aimed at the previous target, the client drops it, and the throttle is
+stamped on a cast that never left. For Hunter's Mark that throttle is **110 seconds** — and the
+sting is gated on the mark being up, so one dropped cast silently costs both for most of two
+minutes. Mark now goes through the same queue the sting does.
+
+### 🐛 Fixed — at low mana, neither ranged nor melee auto-attack started
+
+Two independent causes, both of which had to go.
+
+**The press never got there.** Hunter's Mark leads the rotation; the mana-free Auto Shot sits
+four steps below it. An unaffordable Mark consumed the press anyway, and when that was gated,
+*Aspect upkeep* — one step further down and also paid for in mana — took it instead. So a hunter
+near empty spent every press on casts that could not happen and never reached the one attack that
+still works at zero mana.
+
+The affordability test now sits in this module's own `Pick` and `Queue` rather than at the
+twenty call sites that would eventually forget one — the same argument as the warlock's channel
+gate. An **unreadable cost answers yes**, so a tooltip that failed to populate can never lock a
+step out.
+
+**And the restart never fired.** `lastAutoShot` was a single timestamp with no notion of *which*
+target it belonged to. Tab to a new mob and the shot at the previous one is a fraction of a
+second old, so `EnsureAutoShot` concluded "still firing" and did nothing. It is now qualified by
+target.
+
+Deliberately **not** done: moving the auto-attack step above the spells. The comment there argues
+for the current order — starting Auto Shot costs its own press, and Hunter's Mark would lose to
+it at the pull. That is a priority decision with a stated rationale, not something to change in
+passing.
+
+### ✨ Priest and Mage got the same gate
+
+Neither had the hunter's bug: both already drop to the wand below a mana floor
+(`fillerManaFloor` / `wandManaFloor`, 25% by default), which is the same safety valve the warlock
+carries. But that protects the **filler**; everything above it — DoTs, *Mind Blast*, the cooldown
+spells — was still sent unchecked, so a spell can be unaffordable while the floor has not yet
+been crossed.
+
+A narrower window than the hunter's and not a reported fault. The gate closes it, costs nothing,
+and cannot lock anything out. **Heals are unaffected** — those go out through `CastOn` with a
+unit argument, and their rank is already chosen against available mana.
+
+### 🔧 Cast refusals now distinguish the target from ourselves
+
+The refusal list was one list. It is now two, because they answer different questions:
+line-of-sight, range and facing say the **unit** cannot be reached and mark it; mana, rage and
+energy say something about **us** and clear only that spell's throttle.
+
+Without the split, adding mana to the list would have had a healer marking group members as
+unreachable while they stood in front of him.
+
+---
+
 ## v1.2.9 — The mage can be diagnosed at all (restored), and a changelog repair
 
 ### 🩺 Mage tracing — shipped in the v1.2.8 tree, documented here

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.9)
+# Aegis: Single Button Rotation (v1.2.10)
 
 **One button. Your whole rotation.**
 
@@ -358,6 +358,8 @@ Cat (DPS), Bear (Tank), Balance (Caster/Moonkin), and **Restoration** (group hea
 * **Bear Tanking:** *Faerie Fire (Feral)* as the **ranged opener** (instant, 30yd), optional **Growl** taunt that grabs threat on the pull and whenever the target stops attacking you, *Demoralizing Roar* upkeep, *Maul* as the rage dump, *Swipe* leading under `/sbr aoe`, and optional *Enrage* when rage-starved (in combat only — it lowers armor, so it is off by default). *(Moonfire cannot be cast in bear form, so Faerie Fire is the bear's ranged opener.)*
 * **Form-Aware Auto-Attack:** The white swing is started automatically in **Cat and Bear** (and never while casting in caster/Moonkin) — see the action-bar note in [Using it](#using-it).
 </details>
+
+> **A press is only spent on a cast that can happen.** The shared `Pick` reports success on *"known and learned"*, not on *"accepted"* — so a step that could not be paid for used to consume the press anyway. That matters most where a free attack sits below a paid one: a hunter near empty spent every press on *Hunter's Mark* and Aspect upkeep and never reached Auto Shot, which is the one thing that still works at zero mana. Hunter, Priest and Mage now test affordability in their own send path rather than at each call site. An **unreadable cost answers yes**, so a tooltip that failed to populate can never lock a step out, and heals are untouched (they cast through a different path and already pick their rank against available mana).
 
 > **What the client already knows.** Abilities are no longer cast without the weapon they require (*Shield Slam*, *Shield Block* and *Shield Bash* need a shield; *Backstab* and *Ambush* need a dagger), and *Backstab* is no longer chosen from the front — vanilla has no facing API, but UnitXP_SP3 does. Both checks are **three-state**: an item the client has not cached yet, or a locale whose subtype strings are unknown, answers *"cannot tell"* and changes nothing. Refusing an ability because we failed to identify a weapon would be the worse bug.
 

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -280,7 +280,10 @@ function M:EnsureAutoShot()
         return false
     end
     local now = GetTime()
-    if self.lastAutoShot and self.lastAutoShot > 0 then
+    -- Only trust the last-shot time when it was a shot at THIS target. A recent
+    -- shot at the mob you just tabbed away from says nothing about this one.
+    local sameTarget = (self.lastAutoShotAt == nil) or (self.lastAutoShotAt == self:TargetId())
+    if sameTarget and self.lastAutoShot and self.lastAutoShot > 0 then
         if (now - self.lastAutoShot) < (self:RangedSpeed() + AUTOSHOT_STALL) then
             self:Later(function() self.autoShotOn = true end)
             return false
@@ -305,10 +308,34 @@ function M:EnsureAutoShot()
     return true
 end
 
+-- Everything this module sends goes through one of these two, and both refuse
+-- what cannot be paid for.
+--
+-- `Pick` and `PickQueue` in the core report success on "known and learned", not
+-- on "accepted" - which is correct for them, since most classes check the cost
+-- at the decision. This module did not, and the shape of that mistake is worse
+-- here than elsewhere: Hunter's Mark LEADS the rotation and the mana-free Auto
+-- Shot sits four steps below it. A hunter near empty therefore spent every press
+-- on a cast that never happened and never reached the one attack that still
+-- works at zero mana - reported as "at low mana neither ranged nor melee auto
+-- attack starts on a target switch".
+--
+-- Gated here rather than at the call sites because there are twenty of them and
+-- a new one would eventually forget. The same argument as the warlock's channel
+-- gate.
+--
+-- An unreadable cost answers YES (see CanAfford), so a tooltip that failed to
+-- populate can never lock a step out.
+function M:Pick(name, reason)
+    if not Aegis_SBR:CanAfford(name) then return false end
+    return Aegis_SBR.Pick(self, name, reason)
+end
+
 -- Queue a shot through SuperWoW/Nampower so the weave lands without clipping
 -- the Auto Shot in progress; falls back to a direct cast without the queue.
 function M:Queue(name, reason)
     if not self:KnowsSpell(name) then return false end
+    if not Aegis_SBR:CanAfford(name) then return false end
     if Aegis_SBR.deciding then
         local p = Aegis_SBR.decidePlan
         p.spell = name; p.reason = reason; p.queue = true
@@ -447,7 +474,21 @@ function M:MaintainDebuff(name, interval)
     if rec and rec.id == id and rec.t and (now - rec.t) <= wait then
         return false
     end
-    if not self:Pick(name, "debuff missing") then return false end
+    -- Queued, not cast outright.
+    --
+    -- The comment on MaintainSting below has described this bug since it was
+    -- written - and named this function while doing it: dispatching through the
+    -- instant CastSpellByName path lets the client drop the cast whenever a
+    -- global cooldown is up, which stamps the reapply throttle on a cast that
+    -- never left. For Hunter's Mark that throttle is 110 seconds, and the sting
+    -- is gated on the mark being up, so ONE dropped cast silently costs both for
+    -- most of two minutes.
+    --
+    -- That is exactly what a target switch under a held macro produces: the
+    -- press lands mid-GCD from the cast aimed at the previous target. Reported
+    -- as "switching target by tab or mouse often leaves Hunter's Mark and the
+    -- DoT unapplied".
+    if not self:Queue(name, "debuff missing") then return false end
     self:Later(function()
         self.debuffThrottle[name] = { id = id, t = now }
         Aegis_SBR:NoteDebuffApplied(id, name, interval)
@@ -753,6 +794,11 @@ end
 -- The mana aspect (Viper) swap takes priority in EITHER stance when low, so a
 -- mana-heavy melee hunter recovers the same way a ranged one does; otherwise the
 -- combat aspect for the current state is maintained (Wolf melee / Hawk ranged).
+-- Aspect upkeep. Costs mana, sits one step above the auto-attack floor, and used
+-- to spend the press whether or not it could be paid for - which is the second
+-- half of the low-mana starvation: with Hunter's Mark falling through, the
+-- aspect took the press instead. Pick now refuses an unaffordable cast, so this
+-- returns false and the rotation reaches the swing.
 function M:EnsureAspect(cfg, melee)
     if not cfg.useAspect then return false end
     if self.manaAspectActive then
@@ -1140,6 +1186,7 @@ hunterFrame:SetScript("OnEvent", function()
         M.autoShotTarget = nil
         M.steadyT = 0
         M.lastAutoShot = 0   -- forget the ranged-swing phase between pulls
+        M.lastAutoShotAt = nil
         -- Only the per-GUID half: what was learned per creature TYPE lives in
         -- AegisDB and is meant to outlast the fight.
         M.stingImmune = {}
@@ -1196,7 +1243,15 @@ hunterFrame:SetScript("OnEvent", function()
             if nm == "Auto Shot" then
                 -- "CAST" is the projectile launch (the swing reset); ignore the
                 -- "START" windup so the phase reference is the actual shot.
-                if arg3 == "CAST" then M.lastAutoShot = GetTime() end
+                if arg3 == "CAST" then
+                    M.lastAutoShot = GetTime()
+                    -- Which target it was aimed at. Without this the timestamp
+                    -- is target-blind and a shot at the PREVIOUS mob reads as
+                    -- "still firing" at the new one, so the restart never
+                    -- happens - reported as auto shot not starting after a
+                    -- target switch.
+                    M.lastAutoShotAt = arg2
+                end
             elseif nm == "Steady Shot" then
                 if arg3 == "START" then
                     local d = tonumber(arg5)

--- a/classes/Class_Mage.lua
+++ b/classes/Class_Mage.lua
@@ -197,8 +197,30 @@ end
 -- Cast helper: queue a known spell through SuperWoW's cast queue so a cast in
 -- progress is not clipped. Returns true if the spell is known and was issued.
 -- ============================================================
+-- Everything this module sends goes through one of these two, and both refuse
+-- what cannot be paid for.
+--
+-- `Pick` in the core reports success on "known and learned", not on "accepted",
+-- which is correct for it - most classes check the cost at the decision. This one
+-- did not, and at zero mana the consequence is the same one the hunter was
+-- reported for: every press spent on a cast that never happens, while the free
+-- wand filler sitting at the bottom of the rotation is never reached. The wand is
+-- the one attack that still works at zero mana, and on a target carrying a
+-- mana-return debuff it is how you climb back out.
+--
+-- Gated here rather than at the call sites because there are 28 of them and a
+-- new one would eventually forget.
+--
+-- An unreadable cost answers YES (see CanAfford), so a tooltip that failed to
+-- populate can never lock a step out.
+function M:Pick(name, reason)
+    if not Aegis_SBR:CanAfford(name) then return false end
+    return Aegis_SBR.Pick(self, name, reason)
+end
+
 function M:Queue(name, reason)
     if not self:KnowsSpell(name) then return false end
+    if not Aegis_SBR:CanAfford(name) then return false end
     if Aegis_SBR.deciding then
         local p = Aegis_SBR.decidePlan
         p.spell = name; p.reason = reason; p.queue = true

--- a/classes/Class_Priest.lua
+++ b/classes/Class_Priest.lua
@@ -285,8 +285,33 @@ end
 -- ============================================================
 -- Cast / DoT helpers (mirror the warlock caster pattern)
 -- ============================================================
+-- Everything this module sends goes through one of these two, and both refuse
+-- what cannot be paid for.
+--
+-- `Pick` in the core reports success on "known and learned", not on "accepted",
+-- which is correct for it - most classes check the cost at the decision. This one
+-- did not, and at zero mana the consequence is the same one the hunter was
+-- reported for: every press spent on a cast that never happens, while the free
+-- wand filler sitting at the bottom of the rotation is never reached. The wand is
+-- the one attack that still works at zero mana, and on a target carrying a
+-- mana-return debuff it is how you climb back out.
+--
+-- Gated here rather than at the call sites because there are 15 of them and a
+-- new one would eventually forget.
+--
+-- HEALS ARE NOT AFFECTED: those go out through CastOn with a unit argument, and
+-- their rank is already chosen against available mana.
+--
+-- An unreadable cost answers YES (see CanAfford), so a tooltip that failed to
+-- populate can never lock a step out.
+function M:Pick(name, reason)
+    if not Aegis_SBR:CanAfford(name) then return false end
+    return Aegis_SBR.Pick(self, name, reason)
+end
+
 function M:Queue(name, reason)
     if not self:KnowsSpell(name) then return false end
+    if not Aegis_SBR:CanAfford(name) then return false end
     if Aegis_SBR.deciding then
         local p = Aegis_SBR.decidePlan
         p.spell = name; p.reason = reason; p.queue = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,14 @@ the `AegisUI_*` prefix.)
   refuses. The shield test uses `itemEquipLoc` (a constant) rather than the localised subtype
   string; daggers have no such constant, so that check is an English-client improvement and a
   no-op elsewhere. Facing comes from UnitXP_SP3 — vanilla has no facing API at all.
+- Affordability (v1.2.10): `Aegis_SBR:CanAfford(name)` existed; what did not was any class
+  actually calling it before spending the press. `Pick` / `PickQueue` report success on "known
+  and learned", **not** on "accepted", which is correct for them and a trap for a caller that
+  does not know it. Hunter, Priest and Mage now test in their own `Pick` / `Queue` wrapper rather
+  than at each call site, because there are twenty of them per class and a new one forgets.
+  The failure mode is worst wherever a **free** action sits below a paid one — Auto Shot under
+  Hunter's Mark, the wand under the nukes — since the press is consumed before reaching the only
+  thing that still works when the bar is empty.
 - Per-press memoisation (core, v1.2.7): `Aegis_SBR:NewPress()` bumps `pressToken` where the
   rotation is invoked — **the press is what has to be identified, not the outcome**, which is
   why it is not tied to a cast. The paladin's `WorstHurt` uses it to answer once per press


### PR DESCRIPTION
Two hunter reports about switching target while holding the macro down. Both land on one sentence: **`Pick` reports success on "known and learned", not on "accepted".**

## Fixed — Hunter's Mark and the sting missing after a target switch

The cause has been written down in this file for months, in the comment on `MaintainSting`, which names the guilty function while describing it:

> *"Dispatching a sting through the instant `CastSpellByName` path (**as MaintainDebuff does**) lets Nampower drop it whenever a global cooldown is up, which silently burns the reapply throttle and the sting never fires."*

The sting was moved to the queue when that was written. **Hunter's Mark was left on the path the comment names as broken.**

Which is exactly what a target switch under a held macro produces: the press lands mid-GCD from the cast aimed at the previous target, the client drops it, the throttle is stamped on a cast that never left. Hunter's Mark carries a **110 second** throttle, and the sting is gated on the mark being up — so one dropped cast silently costs both for most of two minutes.

## Fixed — at low mana, neither ranged nor melee auto-attack started

Two independent causes:

**The press never got there.** Hunter's Mark leads the rotation; the mana-free Auto Shot sits four steps below. An unaffordable Mark consumed the press anyway — and once that was gated, *Aspect upkeep* took it instead. A hunter near empty spent every press on casts that could not happen and never reached the one attack that still works at zero mana.

**The restart never fired.** `lastAutoShot` was a single timestamp with no notion of *which* target it belonged to, so a shot at the mob you just tabbed away from read as "still firing".

The affordability test sits in each module's own `Pick`/`Queue` rather than at the twenty call sites that would eventually forget one — the same argument as the warlock's channel gate. An **unreadable cost answers yes**, so a tooltip that failed to populate cannot lock a step out.

**Deliberately not done:** moving the auto-attack step above the spells. The comment there argues for the current order — starting Auto Shot costs its own press and Hunter's Mark would lose to it at the pull. A priority decision with a stated rationale is not something to change in passing.

## Priest and Mage: the same gate, not the same bug

Neither had the hunter's fault — both already drop to the wand below a mana floor (`fillerManaFloor` / `wandManaFloor`, 25%), the same safety valve the warlock carries. I initially reported them as unprotected; that was wrong, and the correction is in the changelog rather than quietly dropped.

What the floor does *not* cover is everything above the filler — DoTs, *Mind Blast*, cooldown spells — which was still sent unchecked, so a spell can be unaffordable before the floor is crossed. Narrower than the hunter's window and not a reported fault. **Heals are unaffected**: they cast through `CastOn` with a unit argument and already pick their rank against available mana.

## Cast refusals now distinguish the target from ourselves

One list became two. Line of sight, range and facing say the **unit** cannot be reached and mark it; mana, rage and energy say something about **us** and clear only that spell's throttle. Without the split, adding mana would have had a healer marking group members as unreachable while they stood in front of him.

## Verification

`scripts/verify.py --all` passes. Reviewed before writing: version strings consistent across `.toc` / core / README, no duplicate function definitions in any file, each new `M:Pick` defined well before its first call site, `PickExtra` (off-GCD, fire-and-continue) deliberately left ungated.

**Untested in game** — this needs a hunter. The telling test is the reported one: hold the macro, switch target by tab and by mouse, at full mana and near empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
