### PR TITLE
Mage: cast directly in the moment after a channel ends

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.10",
+    ver = "1.2.11",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.10
+## Version: 1.2.11
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.11 — The queue was the delay
+
+### ⚡ Mage: cast directly in the moment after a channel ends
+
+Reported as a roughly three second wait between Arcane Missiles on a mage who had
+nothing else trained. **Measured, it was 0.32s per cast — and none of it was the channel
+guard, the rotation, or the network.**
+
+The player built a minimal no-clip macro to compare against, and it settled the question
+by holding everything constant. Its gate is *identical* to Aegis's — same two events, same
+"don't cast while channeling" rule. Then a second macro was run with `CastSpellByName`
+swapped for `QueueSpellByName` and **nothing else changed**. That one was slow too. One
+word, reproduced.
+
+Measured with a macro that prints the gap from `SPELLCAST_CHANNEL_STOP` to the next
+`SPELLCAST_CHANNEL_START`:
+
+| Path | Gap | Cycle | Casts/min |
+|---|---|---|---|
+| `QueueSpellByName` (Aegis) | **0.37s** | 5.46s | 10.99 |
+| `CastSpellByName` (macro) | **0.05s** | 5.14s | 11.67 |
+
+**≈6.2% throughput** for a spec whose entire rotation is one channel.
+
+The 0.05s figure is what proves the cause. It is **below the player's 307ms latency**, so
+channel start is client-predicted and never waited on the server — meaning the 0.37s was
+never network-bound. It was Nampower's queue holding the spell against its own idea of
+when the channel had ended. `docs/dependencies.md` already said so in the abstract:
+*"Aegis IS a casting manager — if a specific interaction misbehaves, suspect queue timing
+first."*
+
+`M:Queue` now casts **directly** within 0.5s of a channel stopping, and queues as before
+otherwise. The queue exists to hold a press until a cast **already in flight** finishes;
+in the moment after a channel ends there is nothing in flight, so it can only add delay.
+
+Deliberately a **window, not a mode**: a press during a Frostbolt still has something real
+to queue behind, and that is the case the queue was added for. Only the post-channel
+moment is carved out. One press is all the window needs — the next press casts, a new
+channel starts, and the guard in `Rotate` takes over again.
+
+**Not done, and worth saying:** two turns of this investigation proposed clearing the
+channel guard at `start + tooltip duration` instead. The measurements killed it. The
+tooltip reads **4s** while the channel measured **5.09s** across five cycles (4.93–5.19),
+so that "fix" would have fired a second early, clipped the real channel, and dropped a
+missile. It was on the *unblock a guard* side that starved Auto Shot on the hunter, and it
+was wrong for the same reason.
+
+*The priest and warlock queue through the same shape and carry the same 0.32s. Left alone
+on purpose — this is the class that was measured, and the mage result should be confirmed
+in play before it is assumed to generalise.*
+
+---
+
 ## v1.2.10 — A press spent on a cast that never happened
 
 Two hunter reports, both about switching target while holding the macro down, and both landing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.10)
+# Aegis: Single Button Rotation (v1.2.11)
 
 **One button. Your whole rotation.**
 

--- a/classes/Class_Mage.lua
+++ b/classes/Class_Mage.lua
@@ -47,6 +47,10 @@ local function msgOut(text, r, g, b) Aegis_SBR:Msg(text, r, g, b) end
 -- on stop. A 16s ceiling guards a missed stop event so the rotation never wedges.
 M.channeling = false
 M.chanStart = 0
+-- When the last channel ENDED. Read by Queue: for a short window after a channel
+-- stops there is provably nothing in flight, so Nampower's queue can only add
+-- delay and the cast goes out directly instead. See the note on Queue.
+M.chanEnd = 0
 local mgChannelFrame = CreateFrame("Frame")
 mgChannelFrame:RegisterEvent("SPELLCAST_CHANNEL_START")
 mgChannelFrame:RegisterEvent("SPELLCAST_CHANNEL_STOP")
@@ -54,9 +58,14 @@ mgChannelFrame:SetScript("OnEvent", function()
     if event == "SPELLCAST_CHANNEL_START" then
         M.channeling = true; M.chanStart = GetTime()
     elseif event == "SPELLCAST_CHANNEL_STOP" then
-        M.channeling = false
+        M.channeling = false; M.chanEnd = GetTime()
     end
 end)
+
+-- How long after a channel stops the direct-cast path is used. One press is all
+-- it needs: the next press casts, a new channel starts, and the guard in Rotate
+-- takes over again. Sized to cover a slow press cadence, not to be a mode.
+local POST_CHANNEL_DIRECT = 0.5
 
 M.modeAlias = { frost = "frost", ice = "frost", fire = "fire",
                 arcane = "arcane", arc = "arcane" }
@@ -226,7 +235,28 @@ function M:Queue(name, reason)
         p.spell = name; p.reason = reason; p.queue = true
         return true
     end
-    if self:Wanding() or not QueueSpellByName then
+    -- Nampower's queue exists to hold a press until a cast ALREADY IN FLIGHT
+    -- finishes, so the next spell goes out without clipping it. Immediately
+    -- after a channel ends nothing is in flight, and there it does the opposite:
+    -- measured on an arcane mage spamming Arcane Missiles, the gap from
+    -- SPELLCAST_CHANNEL_STOP to the next SPELLCAST_CHANNEL_START was 0.37s
+    -- through QueueSpellByName and 0.05s through CastSpellByName - same channel,
+    -- same gate, one word different. On a ~5.09s channel that is 0.32s of dead
+    -- time per cast, about 6% of throughput for a spec whose whole rotation is
+    -- one channel.
+    --
+    -- 0.05s is BELOW the player's 307ms latency, which is the proof that channel
+    -- start is client-predicted and the 0.37s was never network-bound - it was
+    -- the queue holding the spell against its own idea of when the channel ends.
+    -- docs/dependencies.md says as much in the abstract: "Aegis IS a casting
+    -- manager - if a specific interaction misbehaves, suspect queue timing first."
+    --
+    -- Deliberately a WINDOW rather than "always cast directly": a press during a
+    -- Frostbolt still has something real to queue behind, and that is the case
+    -- the queue was added for. Only the post-channel moment is carved out.
+    local direct = self:Wanding() or not QueueSpellByName
+        or (GetTime() - (self.chanEnd or 0)) < POST_CHANNEL_DIRECT
+    if direct then
         CastSpellByName(name)
     else
         QueueSpellByName(name)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,19 @@ the `AegisUI_*` prefix.)
 - Casting primitives: `Cast(name)` (reports success if merely KNOWN — see the caveat in the
   Warrior module header), `Queue(name)` (uses Nampower queueing), `Try(name)` /
   `CanCast(name, cost, stances)` wrappers in some modules.
+- **Queueing is not free when nothing is in flight** (v1.2.11). Nampower's queue exists to
+  hold a press until a cast **already running** finishes. In the moment right after a
+  *channel* ends there is nothing to hold behind, and there it does the opposite: measured
+  on an arcane mage, the gap from `SPELLCAST_CHANNEL_STOP` to the next channel was **0.37s
+  through `QueueSpellByName` and 0.05s through `CastSpellByName`** — same gate, same spell,
+  one word different, ≈6% of throughput. The 0.05s is below that player's 307ms latency,
+  which proves channel start is client-predicted and the loss was never network-bound.
+  `Class_Mage.lua` carves out a 0.5s post-channel window that casts directly (`chanEnd` +
+  `POST_CHANNEL_DIRECT`) and queues as normal otherwise — a window, not a mode, because a
+  press during a Frostbolt still has something real to queue behind. **The priest and
+  warlock have the same shape and have not been measured.** If a class ever looks sluggish
+  coming out of a channel, check which primitive its `Queue` took before looking anywhere
+  else.
 - Shared resource/timing helpers (core, v1.1.8+): `Aegis_SBR:SpellCost(name)` /
   `CanAfford(name)` read a spell's real cost off the spellbook **tooltip** (cached, dropped
   on `SPELLS_CHANGED`/`CHARACTER_POINTS_CHANGED`) instead of a hardcoded table, so a talent


### PR DESCRIPTION
Reported as a roughly three second wait between Arcane Missiles. Measured, it was 0.32s per cast, and none of it was the channel guard, the rotation or the network.

The player built a minimal no-clip macro to compare against, which settled it by holding everything constant. Its gate is identical to ours - same two events, same rule. Running it a second time with CastSpellByName swapped for QueueSpellByName and nothing else changed made it slow too. One word, reproduced.

Gap from SPELLCAST_CHANNEL_STOP to the next SPELLCAST_CHANNEL_START: QueueSpellByName 0.37s, CastSpellByName 0.05s. On a 5.09s channel that is about 6.2% of throughput for a spec whose whole rotation is one channel.

The 0.05s is what identifies the cause: it is below the player's 307ms latency, so channel start is client-predicted and the 0.37s was never network-bound. It was the queue holding the spell against its own idea of when the channel had ended. dependencies.md already said it in the abstract - Aegis is a casting manager, suspect queue timing first.

Queue now casts directly within 0.5s of a channel stopping. The queue exists to hold a press until a cast already in flight finishes; after a channel ends nothing is in flight, so it can only add delay. Deliberately a window rather than "always cast directly", because a press during a Frostbolt still has something real to queue behind, and that is what the queue was added for.

Not done, and recorded in the changelog because it was proposed twice: clearing the channel guard at start + tooltip duration. The tooltip reads 4s while the channel measured 5.09s over five cycles, so it would have fired a second early and clipped the channel. Wrong for the same reason the hunter's Auto Shot regression was wrong - it was on the unblock side.

Priest and warlock share the shape and the 0.32s. Left alone: this is the class that was measured, and the result should be confirmed in play first.


Claude-Session: https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN