### PR TITLE
Mage: a press that does nothing now says so, and stops eating itself (v1.2.12)

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.11",
+    ver = "1.2.12",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.11
+## Version: 1.2.12
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.12 — Mage: a press that does nothing now says so
+
+**v1.2.11 blamed Nampower's queue. That was wrong** — the delay is present with Nampower
+uninstalled, where `QueueSpellByName` does not exist and `M:Queue` already fell through to
+`CastSpellByName`, the identical call the comparison macro makes. The queue was never the
+cause. The 0.37s-vs-0.05s measurement was real, but it was measuring something downstream of
+the actual problem. The v1.2.11 window is kept — it is correct on its own terms and costs
+nothing — but it is not the fix, and the note claiming it was has been corrected.
+
+### 🐛 Fixed — ten filler casts consumed the press when refused
+
+Every other cast site in the module is written `if self:Queue(x) then return end`. The nuke
+fillers — the last line of every spec's rotation — were written
+`if self:KnowsSpell(x) then self:Queue(x); return end`: an **unconditional** return that
+fires whether or not the cast was accepted.
+
+`M:Queue` returns `false` when the spell is unaffordable (the `CanAfford` gate added in
+v1.2.10). So below the cost of one Arcane Missiles the arcane mage did this, every press:
+reach the filler, get refused, **return anyway**. No wand, no fallback, nothing — a press
+that looked identical to a stall. Ten lines across all four rotations had this shape
+(frost, fire, arcane, AoE).
+
+They now fall through, which is what the module's own documented *"nuke then wand"* rule
+always intended: refused nuke → next nuke → wand.
+
+### 🔍 A press that casts nothing now leaves a trace line
+
+This is why the report took as long as it did. `M:Queue` and `M:Pick` could turn a press away
+with **no output whatsoever**, so in a log "it waited" and "it cast, and the spell is simply
+slow" were indistinguishable — and three separate causes were proposed and shipped against
+that ambiguity.
+
+Both refusal paths now trace `skip <spell> (cost)` or `skip <spell> (unknown)`, and a cast
+traces `cast <spell>` or `queue <spell>` — naming **which primitive sent it**. A log now
+answers "what did this press do" outright rather than by inference from what happened next.
+
+### ⚡ `Wanding()` no longer scans 120 action slots twice a press
+
+The miss path walks every action slot looking for an auto-repeat, and it is called at least
+twice per press — once by the trace line, once by `Queue`. An idle mage was paying ~240 API
+calls per press to answer a question that cannot change within a press. Now cached against
+the core's press token, the same way the paladin measures its group once per press
+(`Aegis_SBR:NewPress`, v1.2.7).
+
+---
+
 ## v1.2.11 — The queue was the delay
 
 ### ⚡ Mage: cast directly in the moment after a channel ends

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.11)
+# Aegis: Single Button Rotation (v1.2.12)
 
 **One button. Your whole rotation.**
 

--- a/classes/Class_Mage.lua
+++ b/classes/Class_Mage.lua
@@ -158,13 +158,27 @@ end
 -- ============================================================
 -- Wand helpers (mirror the priest)
 -- ============================================================
+-- Is the wand currently auto-repeating? Cached per press against the core's
+-- press token, because the miss path scans up to 120 action slots and this is
+-- called at least twice on every press - once by the trace line and once by
+-- Queue - so an idle mage was paying 240 API calls a press to answer a question
+-- that cannot change within one press. Same reason the paladin measures the
+-- group once per press (v1.2.7, Aegis_SBR:NewPress).
 function M:Wanding()
+    local tok = Aegis_SBR.pressToken
+    if tok and self.wandingTok == tok then return self.wandingVal end
+    local val = false
     local slot = self.wandSlot
-    if slot and IsAutoRepeatAction(slot) then return true end
-    for s = 1, 120 do
-        if IsAutoRepeatAction(s) then self.wandSlot = s; return true end
+    if slot and IsAutoRepeatAction(slot) then
+        val = true
+    else
+        for s = 1, 120 do
+            if IsAutoRepeatAction(s) then self.wandSlot = s; val = true; break end
+        end
     end
-    return false
+    self.wandingTok = tok
+    self.wandingVal = val
+    return val
 end
 
 -- A mage can only equip a wand in the ranged slot, so an occupied ranged slot
@@ -223,13 +237,31 @@ end
 -- An unreadable cost answers YES (see CanAfford), so a tooltip that failed to
 -- populate can never lock a step out.
 function M:Pick(name, reason)
-    if not Aegis_SBR:CanAfford(name) then return false end
-    return Aegis_SBR.Pick(self, name, reason)
+    -- Traced for the same reason as Queue: a press turned away here used to be
+    -- indistinguishable in the log from a press that never got this far.
+    if not Aegis_SBR:CanAfford(name) then
+        if self:Tracing() then self:Trace("skip " .. name .. " (cost)") end
+        return false
+    end
+    local ok = Aegis_SBR.Pick(self, name, reason)
+    if ok and self:Tracing() then self:Trace("cast " .. name) end
+    return ok
 end
 
 function M:Queue(name, reason)
-    if not self:KnowsSpell(name) then return false end
-    if not Aegis_SBR:CanAfford(name) then return false end
+    -- Both refusals are traced. Until now a press that reached a cast and was
+    -- turned away here produced NO output at all, so a report of "it just waits"
+    -- could not be told apart from "it cast and the spell is slow" - which cost
+    -- several rounds of guessing on the arcane-missiles report. A press that
+    -- does nothing must say so.
+    if not self:KnowsSpell(name) then
+        if self:Tracing() then self:Trace("skip " .. name .. " (unknown)") end
+        return false
+    end
+    if not Aegis_SBR:CanAfford(name) then
+        if self:Tracing() then self:Trace("skip " .. name .. " (cost)") end
+        return false
+    end
     if Aegis_SBR.deciding then
         local p = Aegis_SBR.decidePlan
         p.spell = name; p.reason = reason; p.queue = true
@@ -260,6 +292,11 @@ function M:Queue(name, reason)
         CastSpellByName(name)
     else
         QueueSpellByName(name)
+    end
+    -- Names the spell AND which primitive sent it, so a log answers "what did
+    -- this press do" outright instead of by inference from what happened next.
+    if self:Tracing() then
+        self:Trace((direct and "cast " or "queue ") .. name)
     end
     return true
 end
@@ -419,8 +456,8 @@ function M:RotateFrost(cfg)
     end
 
     -- Frostbolt filler (primary nuke). Fireball covers levels 1-3 before it.
-    if self:KnowsSpell("Frostbolt") then self:Queue("Frostbolt", "main nuke"); return end
-    if self:KnowsSpell("Fireball") then self:Queue("Fireball", "main nuke"); return end
+    if self:Queue("Frostbolt", "main nuke") then return end
+    if self:Queue("Fireball", "main nuke") then return end
     self:Wand()
 end
 
@@ -477,8 +514,8 @@ function M:RotateFire(cfg)
 
     -- Fireball filler (primary nuke). Frostbolt covers very early levels if Fire
     -- was somehow picked before Fireball is up.
-    if self:KnowsSpell("Fireball") then self:Queue("Fireball", "main nuke"); return end
-    if self:KnowsSpell("Frostbolt") then self:Queue("Frostbolt", "main nuke"); return end
+    if self:Queue("Fireball", "main nuke") then return end
+    if self:Queue("Frostbolt", "main nuke") then return end
     self:Wand()
 end
 
@@ -520,9 +557,9 @@ function M:RotateArcane(cfg)
 
     -- Arcane Missiles filler (channel). Frostbolt / Fireball cover the early
     -- levels before Missiles is trained.
-    if self:KnowsSpell("Arcane Missiles") then self:Queue("Arcane Missiles", "main nuke"); return end
-    if self:KnowsSpell("Frostbolt") then self:Queue("Frostbolt", "main nuke"); return end
-    if self:KnowsSpell("Fireball") then self:Queue("Fireball", "main nuke"); return end
+    if self:Queue("Arcane Missiles", "main nuke") then return end
+    if self:Queue("Frostbolt", "main nuke") then return end
+    if self:Queue("Fireball", "main nuke") then return end
     self:Wand()
 end
 
@@ -557,11 +594,11 @@ function M:RotateAoE(cfg)
     end
 
     -- Arcane Explosion: the PBAoE finisher for every spec.
-    if self:KnowsSpell("Arcane Explosion") then self:Queue("Arcane Explosion", "AoE"); return end
+    if self:Queue("Arcane Explosion", "AoE") then return end
 
     -- Low-level fallback: just nuke the target.
-    if self:KnowsSpell("Frostbolt") then self:Queue("Frostbolt", "main nuke"); return end
-    if self:KnowsSpell("Fireball") then self:Queue("Fireball", "main nuke"); return end
+    if self:Queue("Frostbolt", "main nuke") then return end
+    if self:Queue("Fireball", "main nuke") then return end
     self:Wand()
 end
 


### PR DESCRIPTION
## v1.2.11 was wrong, and this says so

It blamed Nampower's queue. **The delay is present with Nampower uninstalled** — where `QueueSpellByName` does not exist and `M:Queue` already fell through to `CastSpellByName`, the identical call the comparison macro makes. The queue was never the cause.

The 0.37s-vs-0.05s measurement was real, but it measured something downstream of the actual problem. The v1.2.11 window is kept — correct on its own terms and free — but the claim that it was the fix is corrected in the changelog rather than quietly left standing.

## Ten filler casts consumed the press when refused

Every other cast site in the module reads `if self:Queue(x) then return end`. The nuke fillers — the **last line of every spec's rotation** — read:

```lua
if self:KnowsSpell(x) then self:Queue(x, "main nuke"); return end
```

An **unconditional** return, whether or not the cast was accepted.

`M:Queue` returns `false` when a spell is unaffordable (the `CanAfford` gate added in v1.2.10). So below the cost of one Arcane Missiles, the arcane mage did this every press: reach the filler, get refused, **return anyway**. No wand, no fallback, nothing — a press indistinguishable from a stall.

Ten lines had this shape, across frost, fire, arcane and AoE. They fall through now, which is what the module's own documented *"nuke then wand"* rule always described: refused nuke → next nuke → wand.

## A press that casts nothing now leaves a trace line

**This is why the report took as many rounds as it did.** `M:Queue` and `M:Pick` could turn a press away with *no output whatsoever*, so in a log "it waited" and "it cast, and the spell is simply slow" were indistinguishable — and three separate causes got proposed against that ambiguity.

Now:
- `skip <spell> (cost)` / `skip <spell> (unknown)` on the refusal paths
- `cast <spell>` / `queue <spell>` on success — naming **which primitive sent it**

A log answers "what did this press do" outright instead of by inference from what happened next.

## `Wanding()` no longer scans 120 action slots twice a press

The miss path walks every action slot looking for an auto-repeat, and it runs at least twice per press — once in the trace line, once in `Queue`. An idle mage was paying ~240 API calls per press to answer a question that cannot change within a press. Cached against the core's press token, the same way the paladin measures its group once per press (`Aegis_SBR:NewPress`, v1.2.7).

## Verification

- `python3 scripts/verify.py --all` green
- Versions in sync: `.toc` · core `ver` · README H1 all **1.2.12**
- No duplicate changelog headers
- No priority order changed. The filler fix changes what happens when a cast is **refused** (previously: nothing) — that is the documented fallback, not a reordering.

## What to check in game

`/sbr log on`, spam Q on the arcane mage, `/reload`. Every press now reports its outcome. If the gap is still there, the log will name the step responsible instead of leaving it to be guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN

---
_Generated by [Claude Code](https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN)_