### PR TITLE
Stop quoting chat messages verbatim, and make it a house rule

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -1068,9 +1068,8 @@ end
 -- Not the same question as "are we moving", and the difference is the whole
 -- point. Stopping is not a commitment to stay stopped: a step to reposition
 -- puts a fraction of a second of stillness in the middle of moving, and a check
--- that only asks "moving right now" fires into it. Described from play, exactly
--- and unkindly: "ah, this person hasn't moved for one second, seems like a good
--- time to fart gold".
+-- that only asks "moving right now" fires into it. That gap was spotted from
+-- play before the first version shipped with it.
 --
 -- So a ground effect asks for a DWELL, not for a moment. What it buys is a
 -- guess that the next few seconds look like the last few - the only guess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,9 +500,10 @@ dealt, and the threat lands on nothing.
 replaces is the accident, not the feature. Off restores casting on cooldown regardless, which a
 tank who repositions constantly may well prefer, since a held Consecration is threat not made.
 
-It waits for a **dwell of two seconds**, not for the instant you stop. That correction came from
-the sharpest review this addon has had: *"rotation going: ah, this person hasn't moved for one
-second, seems like a good time to fart gold"*. Two seconds against an eight second patch is long
+It waits for a **dwell of two seconds**, not for the instant you stop — a correction that came
+from play before this shipped, and the right one: a step to reposition contains a fraction of a
+second of standing still, so a check that only asks "moving right now" drops the patch into
+exactly the gap the switch exists to avoid. Two seconds against an eight second patch is long
 enough that a step is not mistaken for a stand, and short enough that a real fight never waits —
 you are stationary the moment melee starts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,17 @@ calculators block automated access.
   design, because it looks correct in the source.
 
 ## House style
+- **Never quote a play report verbatim.** Reports reach this project as relayed Discord
+  messages, and none of it belongs in `CHANGELOG.md`, `README.md`, a code comment, or a PR
+  body: the person was talking in a chat, not writing for publication. Paraphrase what the
+  observation ESTABLISHED — "a step to reposition contains a fraction of a second of standing
+  still, so checking 'moving right now' is not enough" — and drop the wording, the name and any
+  characterisation of the remark. v1.2.5 shipped a tester's throwaway joke into the changelog
+  under the heading of "the sharpest review this addon has had"; it read as unprofessional to
+  anyone without the context and as mockery to anyone with it, and not one word of the substance
+  was in the quote. Numbers, symptoms and measurements are the useful part and carry none of
+  that risk. **Named credit is the exception, and only when the user asks for it** — the v1.2.0
+  thanks to Holyhollie was requested and stays.
 - Comments explain WHY, not what. Keep the flat-dark UI conventions and palette already in
   the code. Don't introduce new dependencies. Don't refactor unrelated code in a feature
   change. When you fix a class of bug, add a one-line note to this file so it isn't


### PR DESCRIPTION
The v1.2.5 changelog quoted a tester's Discord message word for word and framed it as *"the sharpest review this addon has had"*. It was noticed by readers, and not kindly.

## What was wrong with it

Three things at once:

- **Quoted without asking.** The person was joking in a chat, not writing for publication. Their wording now sits permanently in a repository strangers read.
- **The wording itself** reads as unprofessional to anyone without the context.
- **The framing** is overblown, and read cold it lands as either self-congratulation or mockery at their expense.

It was in two places — `CHANGELOG.md` and a comment in `Aegis_SBR.lua`. Both public.

**None of the substance was in the quote.** What the observation established — a step to reposition contains a fraction of a second of standing still, so checking "moving right now" is not enough — is unchanged and now said plainly.

## The rule, not just the fix

Removing one entry does not stop the next one, so it goes into `CLAUDE.md` under House style, as the first item: paraphrase what a report **established**, never what somebody typed, and drop the name and any characterisation with it. The specific failure is recorded alongside the rule, because a rule without the case that produced it gets argued away.

Named credit stays the exception, and only when the maintainer asks for it — the v1.2.0 thanks to Holyhollie was requested and is untouched.

## Scope

The rest of `CHANGELOG.md` and `README.md` were checked for the same pattern: one further quote from a tester remains, but it is a plain technical sentence with no name and no framing, and it was left alone.

Documentation and one comment only; no addon behaviour changes, so no version cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
