### PR TITLE
Renumber our v1.2.13 to v1.2.14

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.13",
+    ver = "1.2.14",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.13
+## Version: 1.2.14
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,60 +4,7 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
-## v1.2.13 — The client was refusing every first cast, and the message was being thrown away
-
-**The v1.2.12 tracing found it on the first log.** Every channel cycle, the rotation issued
-**two** casts and only the second one took:
-
-```
-7.20|cast Arcane Missiles     mana 86   <- thrown away by the client
-7.38|cast Arcane Missiles     mana 86   <- this one took
-7.58|chan=Y 0.1s              mana 73
-```
-
-Four cycles, identical every time — first cast at 0.28s / 0.33s / 0.34s / 0.30s before the
-channel actually started, mana unmoved across it. **The wasted press is the delay.** The
-rotation was doing everything right and reaching the cast; the client was rejecting it
-because it was still busy finishing the channel.
-
-### 🐛 Fixed — an unrecognised refusal left no trace anywhere
-
-`OnCastError` classified the client's message against two lists and **returned silently on
-anything else**. `RunRotation` then calls `UIErrorsFrame:Clear()`, which wipes the message
-off the screen. So a refusal the addon did not recognise was erased twice over: the addon
-never recorded it, and the player never saw it.
-
-Neither list covered "the client is still busy", which is exactly the refusal that was
-firing here — so the one message that explained the entire report was the one being
-discarded.
-
-This is the failure `CLAUDE.md` warns about in its own rules: *"a detection that cannot
-answer must never close a gate… the symptom is always the same: an ability silently stops
-and nothing says why."*
-
-- **Unrecognised refusals are now traced verbatim**, with the spell that was blamed:
-  `refused? Arcane Missiles :: <the client's own words>`. Deliberately **traced only, not
-  acted on** — `UI_ERROR_MESSAGE` carries far more than cast refusals (full health, bags
-  full, quest text), so treating every one as a refused cast would clear throttles that were
-  correctly set. Naming it is what allows a real one to be added to a list.
-- **"Another action is in progress" and "Spell is not ready yet" added** to the
-  self-refusal list, so a throttle is no longer stamped on a cast the client threw away.
-  Both via the client's own global constants with literal fallbacks, matching the existing
-  entries.
-
-### On the two wrong turns before this
-
-Worth recording, because both were shipped:
-
-- **v1.2.11 blamed Nampower's queue.** Wrong — the delay is present with Nampower
-  uninstalled, where that path is not even reachable.
-- **v1.2.12 fixed ten press-eating filler returns.** A real bug, and it stands, but the log
-  shows the press always reached the cast — so it was not this either.
-
-Both were guesses standing in for a measurement. The thing that actually resolved it was
-the v1.2.12 tracing: once a press could say what it did, one log answered a question three
-rounds of reasoning had not. **The diagnostic should have been built first.**
-## v1.2.13 — Two reports, one guessed second
+## v1.2.14 — Two reports, one guessed second
 
 ### 🐛 Fixed — a target healed to full, then healed again
 
@@ -133,6 +80,59 @@ interrupt rather than inventing one.
 
 ---
 
+## v1.2.13 — The client was refusing every first cast, and the message was being thrown away
+
+**The v1.2.12 tracing found it on the first log.** Every channel cycle, the rotation issued
+**two** casts and only the second one took:
+
+```
+7.20|cast Arcane Missiles     mana 86   <- thrown away by the client
+7.38|cast Arcane Missiles     mana 86   <- this one took
+7.58|chan=Y 0.1s              mana 73
+```
+
+Four cycles, identical every time — first cast at 0.28s / 0.33s / 0.34s / 0.30s before the
+channel actually started, mana unmoved across it. **The wasted press is the delay.** The
+rotation was doing everything right and reaching the cast; the client was rejecting it
+because it was still busy finishing the channel.
+
+### 🐛 Fixed — an unrecognised refusal left no trace anywhere
+
+`OnCastError` classified the client's message against two lists and **returned silently on
+anything else**. `RunRotation` then calls `UIErrorsFrame:Clear()`, which wipes the message
+off the screen. So a refusal the addon did not recognise was erased twice over: the addon
+never recorded it, and the player never saw it.
+
+Neither list covered "the client is still busy", which is exactly the refusal that was
+firing here — so the one message that explained the entire report was the one being
+discarded.
+
+This is the failure `CLAUDE.md` warns about in its own rules: *"a detection that cannot
+answer must never close a gate… the symptom is always the same: an ability silently stops
+and nothing says why."*
+
+- **Unrecognised refusals are now traced verbatim**, with the spell that was blamed:
+  `refused? Arcane Missiles :: <the client's own words>`. Deliberately **traced only, not
+  acted on** — `UI_ERROR_MESSAGE` carries far more than cast refusals (full health, bags
+  full, quest text), so treating every one as a refused cast would clear throttles that were
+  correctly set. Naming it is what allows a real one to be added to a list.
+- **"Another action is in progress" and "Spell is not ready yet" added** to the
+  self-refusal list, so a throttle is no longer stamped on a cast the client threw away.
+  Both via the client's own global constants with literal fallbacks, matching the existing
+  entries.
+
+### On the two wrong turns before this
+
+Worth recording, because both were shipped:
+
+- **v1.2.11 blamed Nampower's queue.** Wrong — the delay is present with Nampower
+  uninstalled, where that path is not even reachable.
+- **v1.2.12 fixed ten press-eating filler returns.** A real bug, and it stands, but the log
+  shows the press always reached the cast — so it was not this either.
+
+Both were guesses standing in for a measurement. The thing that actually resolved it was
+the v1.2.12 tracing: once a press could say what it did, one log answered a question three
+rounds of reasoning had not. **The diagnostic should have been built first.**
 ## v1.2.12 — Mage: a press that does nothing now says so
 
 **v1.2.11 blamed Nampower's queue. That was wrong** — the delay is present with Nampower

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,10 @@ calculators block automated access.
   design, because it looks correct in the source.
 
 ## House style
+- **Write short, neutral and factual.** Changelog entries, PR bodies, commit messages and code
+  comments state what changed, why, and what it affects. No jokes, no irony, no dramatic framing,
+  no rhetorical questions, no long prose where two sentences do. Keep measured numbers and
+  technical detail; cut the framing around them. Prefer a short list or a table to paragraphs.
 - **Never quote a play report verbatim.** Reports reach this project as relayed Discord
   messages, and none of it belongs in `CHANGELOG.md`, `README.md`, a code comment, or a PR
   body: the person was talking in a chat, not writing for publication. Paraphrase what the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.13)
+# Aegis: Single Button Rotation (v1.2.14)
 
 **One button. Your whole rotation.**
 


### PR DESCRIPTION
## Fixed — v1.2.13 was used twice

Two releases carried the same number:

| PR | Change | Merged |
|---|---|---|
| #69 | Heal credit ends on evidence; Repentance immunity learning | first |
| #71 | Mage: cast refusals no longer discarded | second |

PR #71 did not bump the `.toc`, so the number was reused and `CHANGELOG.md` ended up with two `## v1.2.13` headings.

**Ours is renumbered to v1.2.14; PR #71 keeps v1.2.13.** The `.toc`, the core `ver` and the README H1 move to 1.2.14, and the entry moves above v1.2.13 so the file stays ordered by version.

## Also included

House style rule: write short, neutral and factual. Applies to changelog entries, PR bodies, commit messages and code comments. No jokes, no irony, no dramatic framing, no long prose where two sentences do.

Documentation and version strings only; no addon behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
