### PR TITLE
v1.2.15: mage cast bookkeeping, and a correction to v1.2.11–v1.2.13

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.14",
+    ver = "1.2.15",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.14
+## Version: 1.2.15
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.15 — The mage's refusal trace was never wired up
+
+The v1.2.13 fix added a trace for cast refusals the client discards, so an unrecognised
+"why did nothing happen" message would show up as `refused? <spell> :: <message>` instead
+of vanishing. A follow-up log on the same arcane-missiles report showed the double-cast
+pattern was still there — but with **no `refused?` line anywhere**, which meant the trace
+itself was not firing.
+
+### 🐛 Fixed — `Class_Mage.lua` never told the core a cast was sent
+
+`OnCastError` decides whether to trace an unrecognised refusal by checking `self.lastSpell`,
+which is set by `Aegis_SBR:NoteSpellCast`. That is only called from the core's own
+`Pick`/`PickQueue`. The mage module's `M:Queue` and `M:Wand` call `CastSpellByName` /
+`QueueSpellByName` **directly** — that direct call is the entire point of the v1.2.11
+post-channel window — so neither ever told the core a cast had gone out. `OnCastError` saw
+every refusal and had nothing to blame it on, silently.
+
+`M:Queue` and `M:Wand` now call `Aegis_SBR:NoteSpellCast` themselves, matching what
+`Pick`/`PickQueue` already do. `M:Pick` was already correct — it routes through the core's
+`Pick`, which sets this on its own.
+
+Not a rotation change: this makes an existing diagnostic actually run. No ability, gate, or
+order touched.
+
+---
+
 ## v1.2.14 — Two reports, one guessed second
 
 ### 🐛 Fixed — a target healed to full, then healed again

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,60 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
-## v1.2.15 — The mage's refusal trace was never wired up
-
-The v1.2.13 fix added a trace for cast refusals the client discards, so an unrecognised
-"why did nothing happen" message would show up as `refused? <spell> :: <message>` instead
-of vanishing. A follow-up log on the same arcane-missiles report showed the double-cast
-pattern was still there — but with **no `refused?` line anywhere**, which meant the trace
-itself was not firing.
+## v1.2.15 — Mage cast bookkeeping, and a correction to v1.2.11–v1.2.13
 
 ### 🐛 Fixed — `Class_Mage.lua` never told the core a cast was sent
 
-`OnCastError` decides whether to trace an unrecognised refusal by checking `self.lastSpell`,
-which is set by `Aegis_SBR:NoteSpellCast`. That is only called from the core's own
-`Pick`/`PickQueue`. The mage module's `M:Queue` and `M:Wand` call `CastSpellByName` /
-`QueueSpellByName` **directly** — that direct call is the entire point of the v1.2.11
-post-channel window — so neither ever told the core a cast had gone out. `OnCastError` saw
-every refusal and had nothing to blame it on, silently.
+`Aegis_SBR:NoteSpellCast` records the spell last sent. `OnCastError` and
+`SpellRefusedSince` both read it to attribute a refusal to a spell. Only the core's
+`Pick`/`PickQueue` called it.
 
-`M:Queue` and `M:Wand` now call `Aegis_SBR:NoteSpellCast` themselves, matching what
-`Pick`/`PickQueue` already do. `M:Pick` was already correct — it routes through the core's
-`Pick`, which sets this on its own.
+`M:Queue` and `M:Wand` call `CastSpellByName` / `QueueSpellByName` directly — that direct
+call is the point of the v1.2.11 post-channel window — so neither recorded anything. Any
+genuine refusal on those paths (out of range, line of sight, out of mana) had no spell to
+blame and was dropped.
 
-Not a rotation change: this makes an existing diagnostic actually run. No ability, gate, or
-order touched.
+Both now call `NoteSpellCast`, matching `Pick`/`PickQueue`. `M:Pick` was already correct;
+it routes through the core `Pick`.
+
+Not a rotation change. No ability, gate, or order touched.
+
+### ⚠️ Correction — the arcane-missiles delay was misdiagnosed three times
+
+Re-reading the captured log against the reporter's stated 307ms latency shows the earlier
+conclusions were wrong. In every cycle the **first** cast is the one that starts the
+channel, one round trip later:
+
+| Channel start | 1st cast | Δ | 2nd cast | Δ |
+|---|---|---|---|---|
+| 1.18 | 0.87 | 0.31s | 1.03 | 0.15s |
+| 6.60 | 6.24 | 0.36s | 6.43 | 0.17s |
+| 12.07 | 11.74 | 0.33s | 11.93 | 0.14s |
+| 17.60 | 17.25 | 0.35s | 17.47 | 0.13s |
+
+The first-cast deltas match the stated latency. The second-cast deltas are below it, so the
+second cast cannot be what started the channel — it is a redundant press sent while the
+first was still in flight, before `SPELLCAST_CHANNEL_START` arrived. Mana staying flat
+across the first cast, read at the time as proof of a refusal, is explained the same way:
+mana does not drop until the server confirms.
+
+The gap from `SPELLCAST_CHANNEL_STOP` to the next channel is ~0.45s, of which ~0.10s is
+noticing and pressing and ~0.34s is the network. The rotation already casts on the first
+press after the guard opens.
+
+What this means for the three preceding releases:
+
+| Release | Claim | Status |
+|---|---|---|
+| v1.2.11 | Nampower's queue caused the delay | Wrong — delay persists without Nampower |
+| v1.2.12 | Ten filler casts consumed the press when refused | Real bug, stands; not this symptom |
+| v1.2.13 | The client refused every first cast | **Wrong** — the first cast lands |
+
+The v1.2.13 entry is left in place with this correction pointing at it, rather than
+rewritten, since it shipped.
+
+The 0.05s macro measurement that prompted v1.2.11 is not consistent with 307ms latency and
+should be treated as unexplained rather than as evidence.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.14)
+# Aegis: Single Button Rotation (v1.2.15)
 
 **One button. Your whole rotation.**
 

--- a/classes/Class_Mage.lua
+++ b/classes/Class_Mage.lua
@@ -297,13 +297,11 @@ function M:Queue(name, reason)
         QueueSpellByName(name)
     end
     -- This module calls the primitives directly instead of going through the
-    -- core's Pick/PickQueue (that is the whole point of the direct/queue choice
-    -- above), so it must set the same bookkeeping those do. Without this,
-    -- OnCastError's refusal trace (v1.2.13) can never fire for a mage: it reads
-    -- self.lastSpell, which only Pick/PickQueue used to write. The exact bug
-    -- that made the arcane-missiles double-cast invisible a second time - a
-    -- captured log after v1.2.13 still showed no "refused?" line, because
-    -- nothing had told the core a cast was ever sent.
+    -- core's Pick/PickQueue (that is the point of the direct/queue choice above),
+    -- so it must do the bookkeeping those do. NoteSpellCast is what lets
+    -- OnCastError and SpellRefusedSince attribute a refusal to a spell; without
+    -- it, a genuine refusal on this path - out of range, line of sight, out of
+    -- mana - has nothing to blame and is dropped.
     Aegis_SBR:NoteSpellCast(name)
     -- Names the spell AND which primitive sent it, so a log answers "what did
     -- this press do" outright instead of by inference from what happened next.

--- a/classes/Class_Mage.lua
+++ b/classes/Class_Mage.lua
@@ -197,6 +197,9 @@ function M:Wand()
         return true
     end
     CastSpellByName("Shoot")
+    -- Same reason as Queue below: this calls the primitive directly, so it must
+    -- do its own bookkeeping for OnCastError's refusal trace to see it.
+    Aegis_SBR:NoteSpellCast("Shoot")
     return true
 end
 
@@ -293,6 +296,15 @@ function M:Queue(name, reason)
     else
         QueueSpellByName(name)
     end
+    -- This module calls the primitives directly instead of going through the
+    -- core's Pick/PickQueue (that is the whole point of the direct/queue choice
+    -- above), so it must set the same bookkeeping those do. Without this,
+    -- OnCastError's refusal trace (v1.2.13) can never fire for a mage: it reads
+    -- self.lastSpell, which only Pick/PickQueue used to write. The exact bug
+    -- that made the arcane-missiles double-cast invisible a second time - a
+    -- captured log after v1.2.13 still showed no "refused?" line, because
+    -- nothing had told the core a cast was ever sent.
+    Aegis_SBR:NoteSpellCast(name)
     -- Names the spell AND which primitive sent it, so a log answers "what did
     -- this press do" outright instead of by inference from what happened next.
     if self:Tracing() then


### PR DESCRIPTION
## Fixed — `Class_Mage.lua` never told the core a cast was sent

`Aegis_SBR:NoteSpellCast` records the spell last sent; `OnCastError` and `SpellRefusedSince` both read it to attribute a refusal to a spell. Only the core's `Pick`/`PickQueue` called it.

`M:Queue` and `M:Wand` call `CastSpellByName`/`QueueSpellByName` directly — the point of the v1.2.11 post-channel window — so neither recorded anything. A genuine refusal on those paths (range, line of sight, mana) had no spell to blame and was silently dropped.

Both now call `NoteSpellCast`, matching `Pick`/`PickQueue`. `M:Pick` was already correct.

Not a rotation change. No ability, gate, or order touched.

## Correction — the arcane-missiles delay was misdiagnosed three times

Re-reading the captured log against the reporter's stated 307ms latency shows the earlier conclusions were wrong. In every cycle the **first** cast is the one that starts the channel, one round trip later:

| Channel start | 1st cast | Δ | 2nd cast | Δ |
|---|---|---|---|---|
| 1.18 | 0.87 | 0.31s | 1.03 | 0.15s |
| 6.60 | 6.24 | 0.36s | 6.43 | 0.17s |
| 12.07 | 11.74 | 0.33s | 11.93 | 0.14s |
| 17.60 | 17.25 | 0.35s | 17.47 | 0.13s |

The first-cast deltas match the stated latency. The second-cast deltas are *below* it, so the second cast cannot be what started the channel — it's a redundant press sent while the first was still in flight, before `SPELLCAST_CHANNEL_START` arrived. Mana staying flat across the first cast — read at the time as proof of a refusal — is explained the same way: mana doesn't drop until the server confirms.

The gap from `SPELLCAST_CHANNEL_STOP` to the next channel is ~0.45s: ~0.10s noticing and pressing, ~0.34s network. The rotation already casts on the first press after the guard opens.

| Release | Claim | Status |
|---|---|---|
| v1.2.11 | Nampower's queue caused the delay | Wrong — delay persists without Nampower |
| v1.2.12 | Filler casts consumed the press when refused | Real bug, stands; not this symptom |
| v1.2.13 | The client refused every first cast | **Wrong** — the first cast lands |

The v1.2.13 entry is left in place with this correction pointing at it, rather than rewritten, since it shipped.

The 0.05s macro measurement that prompted v1.2.11 is not consistent with 307ms latency and should be treated as unexplained rather than as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN

---
_Generated by [Claude Code](https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN)_