### PR TITLE
v1.2.16: Carve in single target, and a buff fallback that never worked

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.15",
+    ver = "1.2.16",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,
@@ -596,6 +596,44 @@ end
 function Aegis_SBR:HasBuff(name)
     local tl = self:ScanBuff(name)
     return tl ~= nil
+end
+
+-- First player buff whose RESOLVED NAME contains `frag`, or nil. The partial
+-- match HasBuff cannot do: HasBuff needs the exact name, so it cannot answer
+-- "is any Eclipse buff up" when the server's wording is not the one we guessed.
+--
+-- This exists because three modules hand-rolled that fallback with
+-- `UnitBuff("player", i)` and searched the result for a spell NAME - but
+-- UnitBuff's first return is the icon TEXTURE PATH, not a name (see
+-- Aegis_SBR_BuffUp.lua, which names it `tex` and builds a tooltip to get the
+-- name). Searching a file path for "Eclipse" or "Clearcast" matches only if
+-- the artist happened to put that word in the filename, so those fallbacks
+-- were dead. The warlock's copy searched for "Spell_Shadow_Twilight" and was
+-- the only correct one, which is what identified the pattern.
+--
+-- Names come from the same SuperWoW id -> SpellInfo path as ScanBuff, so a
+-- client without it simply finds nothing rather than misreporting.
+function Aegis_SBR:BuffNameContaining(frag)
+    if not frag or frag == "" then return nil end
+    if self.buffSnap and self.buffSnapT == GetTime() then
+        for nm in pairs(self.buffSnap) do
+            if string.find(nm, frag, 1, true) then return nm end
+        end
+        return nil
+    end
+    if not GetPlayerBuff then return nil end
+    for i = 0, 31 do
+        local ix = GetPlayerBuff(i, "HELPFUL")
+        if ix and ix ~= -1 then
+            local id = GetPlayerBuffID and GetPlayerBuffID(ix)
+            if id then
+                if id < -1 then id = id + 65536 end
+                local nm = SpellInfo and SpellInfo(id)
+                if nm and string.find(nm, frag, 1, true) then return nm end
+            end
+        end
+    end
+    return nil
 end
 
 function Aegis_SBR:BuffTime(name)

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.15
+## Version: 1.2.16
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.16 — Carve in single target, and a buff fallback that never worked
+
+### ✨ Hunter: Carve as a single-target filler (Survival melee)
+
+Carve was gated on AoE mode (`Class_Hunter.lua:1006`), so it never fired in single
+target. It now also sits at the **bottom** of the melee priority — after Raptor Strike,
+before Wing Clip — where it can only take a press nothing else wanted. The AoE lead is
+unchanged.
+
+Placed as filler rather than ranked against the strikes deliberately: Carve's damage
+relative to Raptor Strike has not been measured, and filler is the position where being
+wrong about that costs nothing. The shared Multi-Shot cooldown needs no handling in melee,
+where Multi-Shot is not part of the branch.
+
+Approved change; the research documents Carve as an AoE tool, so this is a deliberate
+departure from it rather than a correction.
+
+### 🐛 Fixed — a buff fallback in two modules searched a texture path for a spell name
+
+`UnitBuff("player", i)` returns the icon **texture path** as its first value, not a name.
+`Aegis_SBR_BuffUp.lua:600` is the reference: it names that return `tex` and builds a
+tooltip through `SetUnitBuff` to obtain the name.
+
+Three modules hand-rolled a "check for a differently worded proc" fallback on top of it:
+
+| Module | Searched for | Correct |
+|---|---|---|
+| Warlock | `Spell_Shadow_Twilight` | yes — a texture fragment |
+| Shaman | `Clearcast` | no — a name |
+| Druid | `Eclipse` | no — a name |
+
+The Warlock's is the only working copy and is untouched. The other two could match only if
+the icon filename happened to contain the word, so both were dead code.
+
+New core helper `Aegis_SBR:BuffNameContaining(frag)` returns the first buff whose
+**resolved name** contains a fragment, using the same SuperWoW id → `SpellInfo` path as
+`ScanBuff`. That is the partial match `HasBuff` cannot do, since it requires the exact
+name. Both modules now use it, so the defect cannot recur in a third.
+
+**Impact differs sharply between the two.** On the Shaman the fallback was never reached —
+`HasBuff("Clearcasting")` is almost certainly the right name. On the **Druid it was
+load-bearing**: `EclipseSide()` guesses five possible Eclipse buff names, and when none
+matched, the broken fallback was the only remaining path. It returned `nil` every press, so
+the Eclipse reaction never fired and Balance chain-cast Wrath — the reported symptom.
+
+`EclipseSide()` also gains a side fallback: a buff named for Eclipse but with no side in
+its name now reports `lunar` rather than `nil`. `nil` means "no proc" and drops the
+reaction entirely; guessing lunar costs a cast ratio at worst, where guessing solar
+re-casts the filler already being spammed.
+
+**This may not be the whole Druid fix.** Audit item **D5** remains open on whether Turtle's
+Eclipse is a buff at all — the research reads as rewarding strict Wrath/Starfire
+alternation, which would mean no buff exists and `EclipseSide()` is the wrong model rather
+than a mis-named one. `/sbr debug` with a proc up settles it: it resolves buff names
+correctly (`GetPlayerBuff` → `GetPlayerBuffID` → `SpellInfo`). If a buff appears, its name
+goes into `M.ECLIPSE_LUNAR` / `M.ECLIPSE_SOLAR` and this is finished. If none appears, the
+rotation shape needs revisiting.
+
+---
+
 ## v1.2.15 — Mage cast bookkeeping, and a correction to v1.2.11–v1.2.13
 
 ### 🐛 Fixed — `Class_Mage.lua` never told the core a cast was sent

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.15)
+# Aegis: Single Button Rotation (v1.2.16)
 
 **One button. Your whole rotation.**
 

--- a/classes/Class_Druid.lua
+++ b/classes/Class_Druid.lua
@@ -338,12 +338,23 @@ function M:EclipseSide()
     for i = 1, table.getn(self.ECLIPSE_LUNAR) do
         if self:HasBuff(self.ECLIPSE_LUNAR[i]) then return "lunar" end
     end
-    for i = 1, 32 do
-        local b = UnitBuff("player", i)
-        if b and string.find(b, "Eclipse") then
-            if string.find(b, "Orange") or string.find(b, "Solar") then return "solar" end
-            return "lunar"
-        end
+    -- Fallback: any buff whose real NAME mentions Eclipse, whatever the exact
+    -- wording. This used to scan UnitBuff and search its first return for
+    -- "Eclipse" - but that return is the icon texture PATH, not a name, so it
+    -- could only ever match if the icon filename happened to contain the word.
+    -- The side test below it had the same fault, searching a file path for
+    -- "Orange"/"Solar". Both were dead, which left detection resting entirely
+    -- on one of the five guessed names above being exactly right.
+    local nm = Aegis_SBR:BuffNameContaining("Eclipse")
+    if nm then
+        if string.find(nm, "Solar", 1, true) then return "solar" end
+        if string.find(nm, "Lunar", 1, true) then return "lunar" end
+        -- Named for Eclipse but with no side in the name: report the side we
+        -- cannot rule out rather than nil, since nil means "no proc" and would
+        -- silently drop the reaction entirely. Lunar/Starfire is the safer of
+        -- the two to guess - it is the bigger nuke, so a wrong guess costs a
+        -- cast ratio, where guessing solar re-casts the filler we already spam.
+        return "lunar"
     end
     return nil
 end

--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -1025,6 +1025,21 @@ function M:Rotate(cfg)
         if cfg.useRaptorStrike and self:KnowsSpell("Raptor Strike") and self:IsReady("Raptor Strike") then
             if self:Pick("Raptor Strike", "on cooldown") then return end
         end
+        -- Carve as a single-target filler, BELOW every rotational attack, so it
+        -- can only take a press nothing else wanted. Requested from play.
+        --
+        -- The research documents Carve as an AoE tool (Survival AoE is "Carve +
+        -- Explosive Trap"), which is why the AoE lead above exists and stays. A
+        -- cone hitting one target is still damage on an otherwise idle global,
+        -- and the shared Multi-Shot cooldown costs nothing in melee, where
+        -- Multi-Shot is not part of the branch at all.
+        --
+        -- Placed last rather than ranked against the strikes on purpose: its
+        -- damage relative to Raptor Strike has not been measured, and filler is
+        -- the position where being wrong about that is free.
+        if cfg.useCarve and self:KnowsSpell("Carve") and self:IsReady("Carve") then
+            if self:Pick("Carve", "single-target filler") then return end
+        end
         -- Wing Clip (optional kite / slow).
         if cfg.useWingClip and self:KnowsSpell("Wing Clip") and self:IsReady("Wing Clip") then
             if self:Pick("Wing Clip", "slow") then return end

--- a/classes/Class_Shaman.lua
+++ b/classes/Class_Shaman.lua
@@ -340,11 +340,12 @@ end
 -- 60% cheaper. Tried by name first, then a texture scan as a fallback.
 function M:ClearcastUp()
     if self:HasBuff("Clearcasting") then return true end
-    for i = 1, 32 do
-        local b = UnitBuff("player", i)
-        if b and string.find(b, "Clearcast") then return true end
-    end
-    return false
+    -- Fallback for a differently worded proc. Was scanning UnitBuff's first
+    -- return for "Clearcast", but that return is the icon texture PATH, not a
+    -- name, so it never matched. Harmless in practice - the exact name above
+    -- is almost certainly right - but it was the same defect the druid's
+    -- Eclipse check had, where the fallback WAS load-bearing.
+    return Aegis_SBR:BuffNameContaining("Clearcast") ~= nil
 end
 
 -- The configured shield/shock resolved to a spell name ("" if none/off).


### PR DESCRIPTION
Both changes approved before editing, per Rule #1.

## Hunter: Carve as a single-target filler

Carve was gated on AoE mode (`Class_Hunter.lua:1006`) and never fired in single target. It now also sits at the **bottom** of the melee priority — after Raptor Strike, before Wing Clip — where it can only take a press nothing else wanted. The AoE lead is unchanged.

Filler rather than ranked against the strikes, deliberately: Carve's damage relative to Raptor Strike is unmeasured, and filler is the position where being wrong about that costs nothing. The shared Multi-Shot cooldown needs no handling in melee, where Multi-Shot is not part of the branch.

Worth noting for review: the research documents Carve as an AoE tool ("Carve + Explosive Trap"), which is why the gate existed. This is a deliberate departure from it, not a correction.

## Fixed: a buff fallback in two modules searched a texture path for a spell name

`UnitBuff("player", i)` returns the icon **texture path**, not a name. `Aegis_SBR_BuffUp.lua:600` is the reference implementation — it names that return `tex` and builds a tooltip through `SetUnitBuff` to get the name.

Three modules hand-rolled a "catch a differently worded proc" fallback on top of it:

| Module | Searched for | Correct |
|---|---|---|
| Warlock | `Spell_Shadow_Twilight` | yes — a texture fragment |
| Shaman | `Clearcast` | no — a name |
| Druid | `Eclipse` | no — a name |

The Warlock's is the only working copy and is untouched; comparing the three is what identified the pattern. The other two could match only if the icon filename happened to contain the word, so both were dead code.

New core helper `Aegis_SBR:BuffNameContaining(frag)` returns the first buff whose **resolved name** contains a fragment, via the same SuperWoW id → `SpellInfo` path as `ScanBuff`. That is the partial match `HasBuff` cannot do, since it requires an exact name. Both modules use it now, so this cannot recur in a third.

### Impact differs sharply between the two

- **Shaman** — the fallback was never reached. `HasBuff("Clearcasting")` is almost certainly the right name, so this is hygiene.
- **Druid** — the fallback was **load-bearing**. `EclipseSide()` guesses five possible Eclipse buff names; when none matched, the broken fallback was the only path left. It returned `nil` every press, the Eclipse reaction never fired, and Balance chain-cast Wrath. That is the reported symptom.

`EclipseSide()` also gains a side fallback: a buff named for Eclipse with no side in its name now reports `lunar` rather than `nil`. `nil` means "no proc" and drops the reaction entirely; guessing lunar costs a cast ratio at worst, where guessing solar re-casts the filler already being spammed.

## This may not be the whole Druid fix

Audit item **D5** stays open on whether Turtle's Eclipse is a buff at all. The research reads as rewarding strict Wrath/Starfire alternation, which would mean no buff exists and `EclipseSide()` is the wrong *model* rather than a mis-named one.

`/sbr debug` settles it — verified that it resolves buff names correctly (`GetPlayerBuff` → `GetPlayerBuffID` → `SpellInfo`). With a proc up:

- a buff appears → its name goes into `M.ECLIPSE_LUNAR` / `M.ECLIPSE_SOLAR` and this is finished
- nothing appears → the rotation shape needs revisiting, and D5 is the tracking item

## Verification

- `python3 scripts/verify.py --all` green
- Versions in sync: `.toc` · core `ver` · README H1 all **1.2.16**
- No duplicate changelog headers, no stale version strings
- Branch cut fresh from `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN

---
_Generated by [Claude Code](https://claude.ai/code/session_016rfTXWAfiKYLeEEgLAwUpN)_