### PR TITLE
Hunter: per-stance combat aspect pickers (ranged/melee dropdowns)

### DIFF
--- a/classes/Class_Hunter.lua
+++ b/classes/Class_Hunter.lua
@@ -30,7 +30,7 @@ local M = Aegis_SBR:NewClassModule("HUNTER")
 M.uiTitle = "Hunter"
 -- Rotate runs under Aegis_SBR:Preview without casting (see Pick/Later).
 M.previewReady = true
-M.uiHeight = 878
+M.uiHeight = 938
 M.meleeAutoAttack = false   -- managed here: Auto Shot (ranged) or Attack (melee)
 M.autoAcquireTarget = false -- a ranged class should not auto-pull random mobs; pick targets
 
@@ -76,6 +76,15 @@ local ARCANE_MANA_FLOOR = 50
 -- was. A name nobody has confirmed does not belong in a list that is searched by
 -- "first one known".
 M.MANA_ASPECTS = { "Aspect of the Viper" }
+
+-- Combat aspects the user can pick per stance (config dropdowns). Wolf is the
+-- classic melee aspect and no longer blocks ranged on Turtle; Viper doubles as
+-- the mana aspect, so picking it here simply means "keep Viper up in this
+-- stance". Order here is only the dropdown display order.
+M.COMBAT_ASPECTS = {
+    "Aspect of the Hawk", "Aspect of the Wolf", "Aspect of the Viper",
+    "Aspect of the Beast", "Aspect of the Monkey", "Aspect of the Wild",
+}
 
 -- Stings are mutually exclusive (one debuff slot). Durations are only the
 -- reapply interval on clients without SuperWoW name resolution.
@@ -146,7 +155,7 @@ M.templates = {
         useAimedShot = false, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = false,
         useRaptorStrike = true, useMongooseBite = true, useWingClip = false,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = false, manaAspectPct = 30,
         petAttack = true, useMendPet = true, mendPetHp = 50,
         useKillCommand = false, useBaitedShot = false,
@@ -159,7 +168,7 @@ M.templates = {
         useAimedShot = false, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = false,
         useRaptorStrike = true, useMongooseBite = true, useWingClip = false,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = true, manaAspectPct = 30,
         petAttack = true, useMendPet = true, mendPetHp = 60,
         useKillCommand = true, useBaitedShot = true,
@@ -172,7 +181,7 @@ M.templates = {
         useAimedShot = true, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = false,
         useRaptorStrike = false, useMongooseBite = false, useWingClip = false,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = true, manaAspectPct = 25,
         petAttack = true, useMendPet = true, mendPetHp = 40,
         useKillCommand = false, useBaitedShot = false,
@@ -185,7 +194,7 @@ M.templates = {
         useAimedShot = false, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = true,
         useRaptorStrike = true, useMongooseBite = true, useWingClip = false, useLacerate = true, useCarve = true,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = true, manaAspectPct = 30,
         petAttack = true, useMendPet = true, mendPetHp = 50,
         useKillCommand = false, useBaitedShot = false,
@@ -198,7 +207,7 @@ M.templates = {
         useAimedShot = false, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = false,
         useRaptorStrike = true, useMongooseBite = true, useWingClip = false, useLacerate = true, useCarve = true,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = false, manaAspectPct = 30,
         petAttack = true, useMendPet = true, mendPetHp = 60,
         useKillCommand = true, useBaitedShot = true,
@@ -221,7 +230,7 @@ function M:NormalizeProfile(c)
         useAimedShot = false, aimedOnlyOnProc = true,
         aoeMode = false, useVolley = false, useImmolationTrap = false,
         useRaptorStrike = true, useMongooseBite = true, useWingClip = false,
-        useAspect = true, rangedAspect = "Aspect of the Hawk",
+        useAspect = true, rangedAspect = "Aspect of the Hawk", meleeAspect = "Aspect of the Wolf",
         useManaAspect = false, manaAspectPct = 30,
         petAttack = true, useMendPet = true, mendPetHp = 50,
         petTaunt = false, useLacerate = false, useCarve = false, useAimedOpener = false,
@@ -234,6 +243,7 @@ function M:NormalizeProfile(c)
     if c.mode ~= "ranged" and c.mode ~= "melee" and c.mode ~= "auto" then c.mode = "ranged" end
     if type(c.sting) ~= "string" then c.sting = "Serpent Sting" end
     if type(c.rangedAspect) ~= "string" then c.rangedAspect = "Aspect of the Hawk" end
+    if type(c.meleeAspect) ~= "string" then c.meleeAspect = "Aspect of the Wolf" end
     -- Two-threshold mana-aspect swap: drop to the mana aspect below manaAspectPct,
     -- swap back to the combat aspect at manaAspectBackPct. Older profiles used a
     -- fixed +MANA_ASPECT_HYST hysteresis, so default the back mark to that to
@@ -259,6 +269,16 @@ function M:AvailableStingsOf()
     local out = {}
     for i = 1, table.getn(self.STINGS) do
         if self:KnowsSpell(self.STINGS[i]) then table.insert(out, self.STINGS[i]) end
+    end
+    return out
+end
+
+-- The combat aspects this hunter can actually cast (config dropdowns), so a
+-- level 10 hunter only sees Hawk until the rest are trained.
+function M:AvailableAspectsOf()
+    local out = {}
+    for i = 1, table.getn(self.COMBAT_ASPECTS) do
+        if self:KnowsSpell(self.COMBAT_ASPECTS[i]) then table.insert(out, self.COMBAT_ASPECTS[i]) end
     end
     return out
 end
@@ -796,6 +816,9 @@ end
 -- (manaAspectPct), swap back to the combat aspect at the high mark
 -- (manaAspectBackPct). Both are user-set sliders; the back mark is guarded to
 -- always sit above the low mark so the two edges never collapse into a flap.
+-- Once the mana aspect is taken it is LATCHED: the combat aspect stays blocked
+-- until mana recovers to the high mark, so a mid-fight Viper->Hawk/Wolf swap
+-- below the mark can never drain the player back into Viper.
 function M:UpdateAspectState(cfg)
     if cfg.useManaAspect and self:KnownManaAspect() then
         local mp = self:ManaPct()
@@ -812,7 +835,8 @@ end
 -- Keep the right aspect up. Returns true if an aspect was cast this press.
 -- The mana aspect (Viper) swap takes priority in EITHER stance when low, so a
 -- mana-heavy melee hunter recovers the same way a ranged one does; otherwise the
--- combat aspect for the current state is maintained (Wolf melee / Hawk ranged).
+-- combat aspect picked for the current stance is maintained (user-selectable
+-- dropdowns; defaults Wolf melee / Hawk ranged).
 -- Aspect upkeep. Costs mana, sits one step above the auto-attack floor, and used
 -- to spend the press whether or not it could be paid for - which is the second
 -- half of the low-mana starvation: with Hunter's Mark falling through, the
@@ -825,7 +849,7 @@ function M:EnsureAspect(cfg, melee)
         if ma and not self:HasBuff(ma) then return self:Pick(ma, "mana aspect") end
         return false
     end
-    local want = melee and "Aspect of the Wolf" or (cfg.rangedAspect or "Aspect of the Hawk")
+    local want = melee and (cfg.meleeAspect or "Aspect of the Wolf") or (cfg.rangedAspect or "Aspect of the Hawk")
     if self:KnowsSpell(want) and not self:HasBuff(want) then return self:Pick(want, "aspect upkeep") end
     return false
 end

--- a/classes/Class_Hunter_UI.lua
+++ b/classes/Class_Hunter_UI.lua
@@ -49,6 +49,8 @@ function M:BuildBody(ui, parent)
     L:Header("Aspect")
     self.aspectRow = L:Row{ key = "useAspect", label = "Combat aspect",
         sub = "automatic Hawk / Wolf - switch off to choose your own", onToggle = set("useAspect") }
+    self.rangedAspDD = L:Dropdown("rangedAspect", "Ranged aspect", 180, set("rangedAspect"))
+    self.meleeAspDD = L:Dropdown("meleeAspect", "Melee aspect", 180, set("meleeAspect"))
     self.manaAspRow = L:Row{ key = "useManaAspect", label = "Viper below",
         spell = "Aspect of the Viper", onToggle = set("useManaAspect"),
         slider = { key = "manaAspectPct", min = 0, max = 90, step = 5, suffix = "%", onChange = set("manaAspectPct") } }
@@ -98,7 +100,9 @@ function M:BuildBody(ui, parent)
     ui:Tip(self.wingRow.cb, "Wing Clip", "Optional melee slow / kite tool.")
     ui:Tip(self.lacerateRow.cb, "Lacerate", "Melee bleed, kept rolling on the target in melee mode.")
     ui:Tip(self.carveRow.cb, "Carve", "Melee AoE strike. Leads the melee priority when AoE mode is on (/sbr aoe).")
-    ui:Tip(self.aspectRow.cb, "Combat aspect", "Keeps Aspect of the Hawk up in ranged mode, Aspect of the Wolf in melee mode.", "Switch it OFF and the rotation never touches your aspect at all - the mana swap below included - so you can pick one yourself and it stays. That is the way to run an aspect the rotation has no use for, such as Aspect of the Beast.")
+    ui:Tip(self.aspectRow.cb, "Combat aspect", "Keeps the aspect you pick for each stance up (Hawk ranged / Wolf melee by default).", "Switch it OFF and the rotation never touches your aspect at all - the mana swap below included - so you can pick one yourself and it stays. That is the way to run an aspect the rotation has no use for, such as Aspect of the Beast.")
+    ui:Tip(self.rangedAspDD, "Ranged aspect", "The combat aspect kept up in ranged mode. Default Hawk (+ranged AP); pick any learned aspect, e.g. Viper to keep mana regen as your main aspect.")
+    ui:Tip(self.meleeAspDD, "Melee aspect", "The combat aspect kept up in melee mode. Default Wolf (+melee AP); pick any learned aspect, e.g. Viper to keep mana regen as your main aspect.")
     ui:Tip(self.manaAspRow.cb, "Mana aspect swap", "Swap to Aspect of the Viper when mana drops below the first value, then back to your combat aspect (Hawk ranged / Wolf melee) once mana recovers to the second value.", "Needs Aspect of the Viper, which is learned at level 56. Before that there is nothing to swap to and this does nothing - no other aspect returns mana.")
     ui:Tip(self.manaAspRow.slider, "Viper below", "Drop to Aspect of the Viper when your mana falls under this percent.")
     ui:Tip(self.manaBackRow.slider, "Back to combat at", "Swap back to Aspect of the Hawk/Wolf once mana recovers to this percent. Set it above the 'Viper below' value.")
@@ -146,6 +150,23 @@ function M:RefreshBody(ui, buf)
     ui:BindCheck(self.lacerateRow, buf.useLacerate)
     ui:BindCheck(self.carveRow, buf.useCarve)
     ui:BindCheck(self.aspectRow, buf.useAspect)
+
+    -- melee/ranged aspect pickers: the learned combat aspects only, so a low-level
+    -- hunter sees just the ones they can actually cast; a saved pick that is not yet
+    -- trained shows red "(not learned)" but keeps its value so it applies when trained.
+    local aopts = {}
+    local aavail = self:AvailableAspectsOf()
+    for i = 1, table.getn(aavail) do aopts[i] = { label = aavail[i], value = aavail[i] } end
+    local function aspectDD(dd, v, dflt)
+        local cur = v or dflt
+        local shown, c
+        if self:KnowsSpell(cur) then shown, c = cur, ui.COL.white
+        else shown, c = cur .. " (not learned)", ui.COL.red end
+        ui:SetDropdown(dd, aopts, cur, shown, c)
+    end
+    aspectDD(self.rangedAspDD, buf.rangedAspect, "Aspect of the Hawk")
+    aspectDD(self.meleeAspDD, buf.meleeAspect, "Aspect of the Wolf")
+
     ui:BindCheck(self.manaAspRow, buf.useManaAspect)
     ui:BindCheck(self.petRow, buf.petAttack)
     if Aegis_SBR_Pet then self.petWinRow.cb:SetChecked(Aegis_SBR_Pet:Enabled()) end


### PR DESCRIPTION
Adds meleeAspect profile field (default Aspect of the Wolf) alongside rangedAspect, a COMBAT_ASPECTS list with AvailableAspectsOf() filtered to learned spells, and EnsureAspect upkeep per stance. UI gains ranged/melee aspect dropdowns showing learned aspects, with red '(not learned)' for saved picks not yet trained. Defaults preserve Hawk ranged / Wolf melee.

Fixes Torchlite-bit/Aegis_SBR#84