### PR TITLE
v1.2.27: the swing timer the warrior never read

### DIFF
--- a/Aegis_SBR.lua
+++ b/Aegis_SBR.lua
@@ -17,7 +17,7 @@
 -- ============================================================
 
 Aegis_SBR = {
-    ver = "1.2.26",
+    ver = "1.2.27",
     classes = {},     -- token -> module table
     active = nil,      -- the module for this character's class
     Loaded = false,
@@ -482,6 +482,17 @@ function Aegis_SBR:OnSwingMessage(msg)
     if not msg then return end
     if string.find(msg, "^Your ") then return end   -- a named ability or seal, not a white swing
     if string.find(msg, "^You ") then
+        -- UNIT_CASTEVENT MAINHAND already anchored this swing, and did it
+        -- without the processing latency a chat message carries. Letting the
+        -- message land as well would push lastSwing forward by exactly that
+        -- latency and throw the precision away again.
+        --
+        -- Inside this branch on purpose: the marker belongs to the white swing
+        -- it was set for, so only a white-swing line may consume it.
+        if self.swingFromCastEvent then
+            self.swingFromCastEvent = nil
+            return
+        end
         self.lastSwing = GetTime()
         local mh = UnitAttackSpeed("player")
         if mh and mh > 0 then self.swingSpeed = mh end
@@ -2886,6 +2897,7 @@ function Aegis_SBR:EvalCommand(msg)
         end
         return
     end
+    if cmd == "deps" or cmd == "components" then self:CmdDeps(); return end
     if cmd == "debug" then self:Debug(); return end
     if cmd == "talents" then self:Talents(); return end
     if cmd == "gobbo" then self:CmdGobbo(); return end
@@ -2943,7 +2955,7 @@ function Aegis_SBR:EvalCommand(msg)
     -- capturing a rotation trace to file, not something a player has any use
     -- for. It still works when typed, so it can be handed out on request when
     -- diagnosing a report ("/sbr log on, play a bit, /reload, send me the file").
-    msgOut("commands: ui, list, use, off, new, del, check, reset, acquire, minimap, debug, talents, trace (plus class commands).")
+    msgOut("commands: ui, list, use, off, new, del, check, reset, acquire, minimap, deps, debug, talents, trace (plus class commands).")
 end
 
 -- ============================================================
@@ -2987,6 +2999,91 @@ end
 
 -- Printed once at PLAYER_LOGIN, when the chat frame is ready. ADDON_LOADED
 -- fires too early in the login for a banner to reliably show.
+-- What Aegis leans on, and whether it is actually here.
+--
+-- Every entry is a live PROBE, not a version string or an addon list: a DLL that
+-- failed to inject leaves its globals absent, and that is the only fact the
+-- rotation cares about. UnitXP is called rather than merely looked up, because
+-- the global can exist while the call itself is unavailable.
+--
+-- req = true means the rotation loses something it cannot work around.
+function Aegis_SBR:Deps()
+    local out = {}
+
+    local _, guid = UnitExists("player")
+    table.insert(out, { name = "SuperWoW", req = true,
+        ok = (guid ~= nil) and (SpellInfo ~= nil),
+        why = "unit ids, cast events, casting on a unit without changing target" })
+
+    table.insert(out, { name = "Nampower", req = true,
+        ok = (QueueSpellByName ~= nil),
+        why = "spell queueing, so a press during a cast is not thrown away" })
+
+    local xp = false
+    if UnitXP then
+        local called = pcall(UnitXP, "distanceBetween", "player", "player")
+        xp = called and true or false
+    end
+    table.insert(out, { name = "UnitXP_SP3", req = true, ok = xp,
+        why = "real distance and line of sight" })
+
+    table.insert(out, { name = "ClassicAPI", req = false,
+        ok = (self.HasClassicAPI and self:HasClassicAPI()) and true or false,
+        why = "debuff timers and their caster, exact spell range" })
+
+    table.insert(out, { name = "SuperCleveRoidMacros", req = false,
+        ok = (IsAddOnLoaded and IsAddOnLoaded("SuperCleveRoidMacros")) and true or false,
+        why = "conditional macros, and it takes over auto-attack" })
+
+    return out
+end
+
+-- The full report, on demand. One line each, so it can be read at a glance and
+-- pasted into a bug report.
+function Aegis_SBR:CmdDeps()
+    local d = self:Deps()
+    DEFAULT_CHAT_FRAME:AddMessage("--- Aegis components ---", 1, 0.8, 0.0)
+    for i = 1, table.getn(d) do
+        local e = d[i]
+        local mark, r, g, b
+        if e.ok then
+            mark = "OK      "; r, g, b = 0.4, 1, 0.4
+        elseif e.req then
+            mark = "MISSING "; r, g, b = 1, 0.4, 0.4
+        else
+            mark = "absent  "; r, g, b = 0.7, 0.7, 0.7
+        end
+        DEFAULT_CHAT_FRAME:AddMessage("  " .. mark .. e.name
+            .. (e.req and " (required)" or " (recommended)"), r, g, b)
+        DEFAULT_CHAT_FRAME:AddMessage("      " .. e.why, 0.6, 0.6, 0.6)
+    end
+    DEFAULT_CHAT_FRAME:AddMessage("Links are in the addon's README.", 0.7, 0.7, 0.7)
+end
+
+-- The login summary. Deliberately short: one line when everything required is
+-- there, and a second only when something is not. Anything longer becomes noise
+-- people learn to scroll past, which defeats the point.
+function Aegis_SBR:DepsBannerLines()
+    local d = self:Deps()
+    local miss, opt = {}, {}
+    for i = 1, table.getn(d) do
+        local e = d[i]
+        if not e.ok then
+            if e.req then table.insert(miss, e.name) else table.insert(opt, e.name) end
+        end
+    end
+    if table.getn(miss) > 0 then
+        return "components MISSING: " .. table.concat(miss, ", ")
+            .. " - the rotation runs without them but loses accuracy. /sbr deps",
+            (table.getn(opt) > 0) and ("also not present, recommended: " .. table.concat(opt, ", ")) or nil
+    end
+    if table.getn(opt) > 0 then
+        return "all required components present. Recommended and not present: "
+            .. table.concat(opt, ", ") .. ". /sbr deps", nil
+    end
+    return "all components present. /sbr deps", nil
+end
+
 function Aegis_SBR:Banner()
     if self.Loaded then return end
     self.Loaded = true
@@ -3004,15 +3101,17 @@ function Aegis_SBR:Banner()
     -- PLAYER_LOGIN is the first point where every DLL has certainly injected
     -- and the chat frame can show the result. Guarded because the capability
     -- file is optional in the load order, exactly like Preview and Pet.
-    if self.DetectClassicAPI then
-        self:DetectClassicAPI()
-        local line = self:ClassicAPIBannerLine()
-        if self:HasClassicAPI() then
-            DEFAULT_CHAT_FRAME:AddMessage("Aegis: " .. line, 0.4, 1, 0.4)
-        else
-            DEFAULT_CHAT_FRAME:AddMessage("Aegis: " .. line, 0.7, 0.7, 0.7)
-        end
+    if self.DetectClassicAPI then self:DetectClassicAPI() end
+    -- One line, two only when something required is missing. Players kept asking
+    -- whether SuperWoW and the rest were actually loaded, and until now the only
+    -- answer was a separate command nobody knew about.
+    local a, b = self:DepsBannerLines()
+    if string.find(a, "MISSING", 1, true) then
+        DEFAULT_CHAT_FRAME:AddMessage("Aegis: " .. a, 1, 0.4, 0.4)
+    else
+        DEFAULT_CHAT_FRAME:AddMessage("Aegis: " .. a, 0.4, 1, 0.4)
     end
+    if b then DEFAULT_CHAT_FRAME:AddMessage("Aegis: " .. b, 0.7, 0.7, 0.7) end
 end
 
 -- Slash commands. /sbr is primary, /aegis the long form; /ar stays as a
@@ -3088,7 +3187,10 @@ ev:SetScript("OnEvent", function()
         Aegis_SBR:OnCastError(arg1)
     elseif event == "PLAYER_REGEN_ENABLED" then
         Aegis_SBR:ClearDebuffLedger()
-        if Aegis_SBR.active then Aegis_SBR.active.lastSwing = nil end
+        if Aegis_SBR.active then
+            Aegis_SBR.active.lastSwing = nil
+            Aegis_SBR.active.swingFromCastEvent = nil
+        end
         -- Out of combat the kill curve is meaningless, and keeping it would let
         -- the last fight's rate answer the first press of the next one.
         Aegis_SBR:ResetTTK()
@@ -3107,6 +3209,21 @@ ev:SetScript("OnEvent", function()
             local sname
             if arg4 and SpellInfo then sname = SpellInfo(arg4) end
             if sname then Aegis_SBR.active:OnCastEvent(arg1, arg2, sname) end
+        end
+        -- Our own white swing landing, straight from SuperWoW.
+        --
+        -- The combat log carries the same fact as text, but it arrives with the
+        -- delay of being formatted, routed and parsed. The event does not, so
+        -- this is the better anchor wherever SuperWoW is present; OnSwingMessage
+        -- stays as the fallback for clients without it.
+        if arg3 == "MAINHAND" then
+            local _, myGuid = UnitExists("player")
+            if arg1 and myGuid and arg1 == myGuid and Aegis_SBR.active then
+                Aegis_SBR.active.lastSwing = GetTime()
+                Aegis_SBR.active.swingFromCastEvent = true
+                local mh = UnitAttackSpeed("player")
+                if mh and mh > 0 then Aegis_SBR.active.swingSpeed = mh end
+            end
         end
         -- Probe log: our OWN finisher casts, to read back what duration the
         -- server actually granted for the combo points spent.

--- a/Aegis_SBR.toc
+++ b/Aegis_SBR.toc
@@ -2,7 +2,7 @@
 ## Title: Aegis: Single Button Rotation
 ## Notes: Configurable one-button rotation, multi class (Turtle WoW 1.18.1 (1.12 client) / SuperWoW). Formerly AutoRota.
 ## Author: Mercaius & Subtilizer (Torchlite)
-## Version: 1.2.26
+## Version: 1.2.27
 ## SavedVariablesPerCharacter: AegisDB, AutoRotaDB, AegisLog, AegisProbe
 
 Aegis_SBR.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to **Aegis: Single Button Rotation** (formerly **AutoRota**)
 
 ---
 
+## v1.2.27 — the swing timer the warrior never read
+
+Thanks to **Dio**, who found all three of these and wrote the fixes.
+
+### 🐛 Fixed — Warrior: the Slam swing gate had never closed
+
+Slam stands down when its cast would run past your next white swing. It never did.
+
+The swing tracker keeps its state on the class **module** — `OnSwingMessage` is called as
+`Aegis_SBR.active:OnSwingMessage(...)` — and the warrior asked the core table for it instead.
+Nothing writes a swing time there, so the answer was always nil, and an unknown swing timer
+lets Slam through by design. The gate was open on every press since it was written.
+
+One word: `Aegis_SBR:SwingTimeLeft()` became `self:SwingTimeLeft()`. The paladin, which had
+always asked `self:`, was the comparison that turned it up.
+
+### 🔧 The swing timer is anchored on the event, not the chat line
+
+SuperWoW reports our own white swing landing through `UNIT_CASTEVENT` with type `MAINHAND`.
+The combat log carries the same fact as text, but it arrives after being formatted, routed and
+parsed, and that delay went straight into the timer.
+
+The event is now the anchor wherever SuperWoW is present, and the combat-log line for the same
+swing is skipped so it cannot push the timestamp forward again. `OnSwingMessage` stays as the
+fallback for clients without it.
+
+### 🐛 Fixed — Warrior: Overpower was dropped on a cast that never went out
+
+`Pick` answers true when the spell is **known**, not when the client accepted the cast. The
+Overpower window was closed on that answer, so a refusal — a stance edge, latency — spent the
+window on nothing and Overpower was skipped silently.
+
+The window now stays open until the client has answered: a refusal within half a second leaves
+it open for the next press, no refusal closes it as spent. A fresh dodge clears any unresolved
+attempt, since that one belonged to the window that just ended.
+
+---
+
 ## v1.2.26 — movement measured on its own clock
 
 ### 🐛 Fixed — all classes: movement was measured between key presses

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Single Button Rotation (v1.2.26)
+# Aegis: Single Button Rotation (v1.2.27)
 
 **One button. Your whole rotation.**
 
@@ -280,7 +280,7 @@ A roleless, toggle-driven engine covering Arms, Fury, and Protection from early 
 - **Threat Toolkit:** Maintains *Sunder Armor* up to a chosen stack count and weaves *Shield Slam*, *Revenge*, and *Shield Block* upkeep for Protection tanking.
 - **Shout Upkeep:** *Battle Shout* (on by default) is kept up as the party attack-power buff — refreshed only when it's missing or about to expire and placed **below your strikes**, so it costs a global cooldown only about once every two minutes and never delays a strike. *Demoralizing Shout* (off by default) keeps the enemy attack-power reduction on your target for tanking, re-applied only when it drops. Both yield during *Execute* and are rage-gated.
 - **Concussion Blow (opt-in):** The Protection talent, off by default and inert until talented. It costs **no rage and generates 10**, is instant on a 20s cooldown, stuns for 3s and ignores armor — free threat that funds your next *Shield Slam*. It currently sits just below your spec's primary strike, the conservative placement; being free, there is a case for putting it higher, and that is a change waiting on somebody who tanks.
-- **Slam knows when to wait:** It yields while a primary strike (*Mortal Strike*, *Bloodthirst*, *Shield Slam*, *Whirlwind*) is off cooldown and only short of rage — Slam is the cheapest ability in the list and used to take those presses — and it stands down when its cast would run past your next white swing. Turtle's Slam is a **2.5s** cast, 1.9s with *Improved Slam*, so against a slow two-hander that second gate is tight by nature.
+- **Slam knows when to wait:** It yields while a primary strike (*Mortal Strike*, *Bloodthirst*, *Shield Slam*, *Whirlwind*) is off cooldown and only short of rage — Slam is the cheapest ability in the list and used to take those presses — and it stands down when its cast would run past your next white swing. Turtle's Slam is a **2.5s** cast, 1.9s with *Improved Slam*, so against a slow two-hander that second gate is tight by nature. The swing timer behind it is anchored on SuperWoW's own auto-attack event where that is available, which is a cleaner timestamp than the combat-log line carrying the same fact.
 - **Cancel Slam for Execute (on by default):** A Slam still casting when *Execute* comes up is interrupted, so the press lands the Execute instead of waiting the cast out. Only once Execute could actually go out: Slam starts the global cooldown when the cast starts and the cast is longer than the cooldown, so cancelling any earlier would throw the Slam away without gaining anything.
 - **Whirlwind leads in AoE:** Checked ahead of the primary strike while `/sbr aoe` is on, since it hits everything in range where *Mortal Strike* hits one. The single-target rage dump keeps its usual place.
 - **Overpower learns its own window:** The reactive window starts when the combat log tells us the target dodged, which is later than the dodge itself — so its tail used to fire into a window the server had already closed. When the client refuses an Overpower, the window shortens to just under the age of that attempt. It only ever shrinks, and never below a floor.
@@ -622,6 +622,12 @@ Four requests:
    `docs/audit-phase1-rotations.md` as a discussion, not a silent edit.
 4. Bump the version in **all three** spots (`.toc`, `ver` in `Aegis_SBR.lua`, the README
    version badge) and add a line to [`CHANGELOG.md`](CHANGELOG.md).
+
+## Thanks
+
+**Dio** found the reason the warrior's Slam swing gate had never worked — the swing timer is
+kept on the class module, and the warrior was the one class asking the core for it — and
+contributed the auto-attack event anchor and the Overpower retry that came with it.
 
 ## License
 

--- a/classes/Class_Warrior.lua
+++ b/classes/Class_Warrior.lua
@@ -372,6 +372,23 @@ local WEAPON_REQ = {
 -- consequence of a false positive is a marginally tighter window rather than a
 -- wrong cast.
 function M:OverpowerLearnTick()
+    -- Resolve the previous Overpower attempt.
+    --
+    -- Pick returns true when the spell is KNOWN, not when the client accepted
+    -- the cast. Closing the window on that answer threw it away whenever the
+    -- cast was refused - a stance edge, latency - and Overpower was skipped
+    -- silently. The window is left open until the client has answered instead:
+    -- refused, and the next press retries; no refusal within half a second, and
+    -- it counts as spent.
+    if self.overpowerAttemptAt and (GetTime() - self.overpowerAttemptAt) > 0.5 then
+        if Aegis_SBR.SpellRefusedAnySince
+            and Aegis_SBR:SpellRefusedAnySince("Overpower", self.overpowerAttemptAt) then
+            if self:Tracing() then self:Trace("overpower refused, window stays open") end
+        else
+            self.overpowerExpiry = 0
+        end
+        self.overpowerAttemptAt = nil
+    end
     if not self.opSentAt then return end
     if GetTime() - self.opSentAt > 2 then
         self.opSentAt, self.opSentAge = nil, nil
@@ -470,8 +487,16 @@ end
 -- wrong here costs a fraction of a swing rather than a whole one - which is why
 -- an estimate is good enough. An UNKNOWN swing timer answers yes, in line with
 -- the rest of the addon: a detection that cannot answer must not close a gate.
+-- Read on SELF, not on Aegis_SBR.
+--
+-- The swing tracker keeps its state on the class MODULE - OnSwingMessage is
+-- called as Aegis_SBR.active:OnSwingMessage(...) - so asking the core table
+-- reads a lastSwing nothing ever writes. SwingTimeLeft then answered nil on
+-- every press, and an unknown swing timer lets Slam through by design, so this
+-- gate had never once closed. The paladin, which asks self:, was right all
+-- along; this was the difference between the two.
 function M:SlamFitsBeforeSwing()
-    local left = Aegis_SBR:SwingTimeLeft()
+    local left = self:SwingTimeLeft()
     if not left then return true end
     return left >= self:SlamCastTime()
 end
@@ -760,7 +785,10 @@ function M:Rotate(cfg)
                     -- still be attributed to this attempt and its age.
                     self.opSentAt = GetTime()
                     self.opSentAge = self.overpowerAt and (GetTime() - self.overpowerAt) or nil
-                    self.overpowerExpiry = 0
+                    -- NOT overpowerExpiry = 0: see OverpowerLearnTick. A send
+                    -- is not an accepted cast, so the window closes only once
+                    -- the client has answered.
+                    self.overpowerAttemptAt = GetTime()
                 end)
                 return
             end
@@ -1057,6 +1085,9 @@ reactFrame:SetScript("OnEvent", function()
             -- the age of an attempt can be worked out afterwards.
             M.overpowerAt = GetTime()
             M.overpowerExpiry = M.overpowerAt + M.opWindow
+            -- An unresolved attempt belonged to the window that just ended; a
+            -- fresh dodge opens a new one, and the leftover must not decide it.
+            M.overpowerAttemptAt = nil
         end
         return
     end


### PR DESCRIPTION
Found and fixed by **Dio** — all three changes here are his analysis and his code.

## The Slam swing gate had never closed

Slam stands down when its cast would run past your next white swing. It never did.

The swing tracker keeps its state on the class **module** — `OnSwingMessage` is called as `Aegis_SBR.active:OnSwingMessage(...)` — and the warrior asked the core table for it instead. Nothing writes a swing time there, so `SwingTimeLeft` answered nil on every press, and an unknown swing timer lets Slam through by design. The gate had been open since it was written.

One word: `Aegis_SBR:SwingTimeLeft()` → `self:SwingTimeLeft()`. The paladin, which had always asked `self:`, was the comparison that turned it up.

## The swing timer is anchored on the event, not the chat line

SuperWoW reports our own white swing landing through `UNIT_CASTEVENT` with type `MAINHAND`. The combat log carries the same fact as text, but arrives after being formatted, routed and parsed, and that delay went into the timer.

The event is now the anchor where SuperWoW is present; the combat-log line for that same swing is skipped so it cannot push the timestamp forward again. `OnSwingMessage` stays as the fallback without it.

## Overpower was dropped on a cast that never went out

`Pick` answers true when the spell is **known**, not when the client accepted the cast, so a refusal — a stance edge, latency — spent the window on nothing and Overpower was skipped silently. The window now stays open until the client has answered: a refusal within half a second leaves it open for the next press, no refusal closes it as spent. A fresh dodge clears any unresolved attempt.

## Verification

`scripts/verify.py --all` passes. The logic was compared line by line against Dio's own copy with comments stripped; only nesting and variable naming differ. One placement was taken from his version over mine: the combat-log suppression sits inside the white-swing branch, so only a white-swing line can consume the marker.

Not yet re-tested in play here — nobody on this side has a warrior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)